### PR TITLE
Migrate more AMM docs and update tx result codes

### DIFF
--- a/docs/xls-30d-amm/ledger-object-types/accountroot.md
+++ b/docs/xls-30d-amm/ledger-object-types/accountroot.md
@@ -1,0 +1,26 @@
+# AccountRoot
+
+The XLS-30d proposal includes some changes to the existing [AccountRoot ledger entry type](https://xrpl.org/accountroot.html).
+
+## AccountRoot Flags
+
+There is a new flag:
+
+| Flag Name | Hex Value    | Decimal Value | Corresponding [AccountSet Flag](https://xrpl.org/accountset.html#accountset-flags) | Description |
+|-----------|--------------|---------------|-----------------------------------|----|
+| `lsfAMM`  | `0x02000000` | 33554432      | (None)                            | This flag indicates that the account is an Automated Market Maker instance. |
+
+You cannot set this flag on normal accounts.
+
+## Special AMM AccountRoot Objects
+
+Automated Market Makers use an AccountRoot object to issue their LP Tokens and hold the assets in the AMM pool, and an [AMM object](amm.md) for tracking some of the details of the AMM. The address of an AMM's AccountRoot is randomized so that users cannot identify and fund the address in advance of the AMM being created. Unlike normal accounts, AMM AccountRoot objects are created with the following settings:
+
+- `lsfAMM` **enabled**. This indicates that the AccountRoot is part of an AMM and is not a regular account.
+- `lsfDisableMaster` **enabled** and no other means of authorizing transactions. This ensures no one can control the account directly, and it cannot send transactions.
+- `lsfRequireAuth` **enabled** and no accounts preauthorized. This ensures that the only way to add money to the AMM Account is using the [AMMDeposit transaction](../transaction-types/ammdeposit.md).
+- `lsfDefaultRipple` **enabled**. This ensures that users can send and trade the AMM's LP Tokens among themselves.
+
+These special accounts are not subject to the [reserve requirement](https://xrpl.org/reserves.html) but they can hold XRP if it is one of the two assets in the AMM's pool.
+
+In most other ways, these accounts function like ordinary accounts; the LP Tokens they issue behave like other [tokens](https://xrpl.org/tokens.html) except that those tokens can also be used in AMM-related transactions. You can check an AMM's balances and the history of transactions that affected it the same way you would with a regular account.

--- a/docs/xls-30d-amm/public-api-methods/ledger_entry.md
+++ b/docs/xls-30d-amm/public-api-methods/ledger_entry.md
@@ -8,7 +8,7 @@ Retrieve an Automated Market-Maker (AMM) object from the ledger. This is similar
 
 | Field        | Type             | Description           |
 |:-------------|:-----------------|:----------------------|
-| `amm`        | Object or String | The [AMM](amm.html) to retrieve. If you specify a string, it must be the [object ID](https://xrpl.org/ledger-object-ids.html) of the AMM, as hexadecimal. If you specify an object, it must contain `asset` and `asset2` sub-fields. |
+| `amm`        | Object or String | The [AMM](../ledger-object-types/amm.md) to retrieve. If you specify a string, it must be the [object ID](https://xrpl.org/ledger-object-ids.html) of the AMM, as hexadecimal. If you specify an object, it must contain `asset` and `asset2` sub-fields. |
 | `amm.asset`  | Object           | One of the two assets in this AMM's pool, as a [currency object without an amount](https://xrpl.org/
 ](currency-formats.htcurrency-formats.html#specifying-without-amounts). |
 | `amm.asset2` | Object           | The other of the two assets in this AMM's pool, as a [currency object without an amount](https://xrpl.org/

--- a/docs/xls-30d-amm/public-api-methods/ledger_entry.md
+++ b/docs/xls-30d-amm/public-api-methods/ledger_entry.md
@@ -1,0 +1,58 @@
+# ledger_entry
+
+XLS-30d extends the existing [ledger_entry method](https://xrpl.org/ledger_entry.html) so that it can be used to retrieve an AMM object.
+
+### Get AMM Object
+
+Retrieve an Automated Market-Maker (AMM) object from the ledger. This is similar to [amm_info method](amm_info.md), but the `ledger_entry` version returns only the ledger entry as stored.
+
+| Field        | Type             | Description           |
+|:-------------|:-----------------|:----------------------|
+| `amm`        | Object or String | The [AMM](amm.html) to retrieve. If you specify a string, it must be the [object ID](https://xrpl.org/ledger-object-ids.html) of the AMM, as hexadecimal. If you specify an object, it must contain `asset` and `asset2` sub-fields. |
+| `amm.asset`  | Object           | One of the two assets in this AMM's pool, as a [currency object without an amount](https://xrpl.org/
+](currency-formats.htcurrency-formats.html#specifying-without-amounts). |
+| `amm.asset2` | Object           | The other of the two assets in this AMM's pool, as a [currency object without an amount](https://xrpl.org/
+](currency-formats.htcurrency-formats.html#specifying-without-amounts). |
+
+
+```json WebSocket
+{
+  "id": 30,
+  "command": "ledger_entry",
+  "amm": {
+    "asset": {
+      "currency": "XRP"
+    },
+    "asset2": {
+      "currency" : "TST",
+      "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+    }
+  }
+  "ledger_index": "validated"
+}
+```
+
+```json JSON-RPC
+{
+    "method": "ledger_entry",
+    "params": [
+        {
+          "amm": {
+            "asset": {
+              "currency": "XRP"
+            },
+            "asset2": {
+              "currency" : "TST",
+              "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
+            }
+          },
+          "ledger_index": "validated"
+        }
+    ]
+}
+```
+
+```sh Commandline
+rippled json ledger_entry '{ "amm": { "asset": { "currency": "XRP" }, "asset2": { "currency" : "TST", "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd" } }, "ledger_index": "validated" }'
+```
+

--- a/docs/xls-30d-amm/transaction-result-codes/index.md
+++ b/docs/xls-30d-amm/transaction-result-codes/index.md
@@ -1,0 +1,27 @@
+# AMM Transaction Result Codes
+
+XLS-30d adds new result codes for transactions. (AMM-related transactions also reuse some existing result codes where appropriate.)
+
+## ter Codes
+
+| Code             | Explanation                                               |
+|:-----------------|:----------------------------------------------------------|
+| `terNO_AMM`      | The AMM-related transaction specifies an asset pair that does not currently have an AMM instance. |
+
+## tec Codes
+
+| Code                     | Value | Explanation                             |
+|:-------------------------|:------|:----------------------------------------|
+| `tecAMM_UNFUNDED`        | 162   | The [AMMCreate transaction](../transaction-types/ammcreate.md) failed because the sender does not have enough of the specified assets to fund it. |
+| `tecAMM_BALANCE`         | 163   | The [AMMDeposit](../transaction-types/ammdeposit.md) or [AMMWithdraw](../transaction-types/ammwithdraw.md) failed because either the AMM or the user does not hold enough of one of the specified assets. (For example, you tried to withdraw more than the AMM holds.) |
+| `tecAMM_FAILED_DEPOSIT`  | 164   | The [AMMDeposit transaction](../transaction-types/ammdeposit.md) failed, probably because the sender does not have enough of the specified assets, or because the deposit requested an effective price that isn't possible with the available amounts. |
+| `tecAMM_FAILED_WITHDRAW` | 165   | The [AMMWithdraw transaction](../transaction-types/ammwithdraw.md) failed, probably because the sender does not have enough LP Tokens, or because the withdraw requested an effective price that isn't possible with the available amounts. |
+| `tecAMM_INVALID_TOKENS`  | 166   | The AMM-related transaction failed due to insufficient LP Tokens or problems with rounding; for example, depositing a very small amount of assets could fail if the amount of LP Tokens to be returned rounds down to zero. |
+| `tecAMM_FAILED_BID`      | 167   | The [AMMBid transaction](../transaction-types/ammbid.md) failed, probably because the price to win the auction was higher than the specified maximum value or the sender's current balance. |
+| `tecAMM_FAILED_VOTE`     | 168   | The [AMMVote transaction](../transaction-types/ammvote.md) failed, probably because there are already too many votes from accounts that hold more LP Tokens for this AMM. (This can still recalculate the AMM's trading fee.) |
+
+## tem Codes
+
+| Code                | Explanation                                   |
+|:--------------------|:----------------------------------------------|
+| `temAMM_BAD_TOKENS` | The transaction incorrectly specified one or more assets. For example, the asset's issuer does not match the corresponding asset in the AMM's pool, or the transaction specified the same asset twice. |

--- a/docs/xls-30d-amm/transaction-types/ammbid.md
+++ b/docs/xls-30d-amm/transaction-types/ammbid.md
@@ -67,7 +67,6 @@ In addition to the common fields, AMMBid transactions use the following fields:
 | `BidMax`       | [Currency Amount][] | Amount            | No        | Pay at most this amount for the slot. If the cost to win the bid is higher than this amount, the transaction fails. If omitted, pay as much as necessary to win the bid. |
 | `AuthAccounts` | Array               | STArray           | No        | A list of up to 4 additional accounts that you allow to trade at the discounted fee. This cannot include the address of the transaction sender. Each of these objects should be an [Auth Account object](#auth-account-objects). |
 
-You cannot specify both `BidMin` and `BidMax`.
 
 ### Auth Account Objects
 
@@ -130,9 +129,9 @@ Besides errors that can occur for all transactions, AMMBid transactions can resu
 |:------------------------|:---------------------------------------------|
 | `tecAMM_FAILED_BID`     | This transaction could not win the auction, either because the sender does not hold enough LP Tokens to pay the necessary bid or because the price to win the auction was higher than the transaction's specified `BidMax` value. |
 | `tecAMM_INVALID_TOKENS` | The sender of this transaction does not hold enough LP Tokens to meet the slot price. |
-| `temBAD_AMM_TOKENS`     | The specified `BidMin` or `BidMax` were not specified as the correct LP Tokens for this AMM. |
-| `temBAD_AMM_OPTIONS`    | The transaction specified invalid options, such as a list of `AuthAccounts` that is too long, or specifying both `BidMin` and `BidMax`. |
+| `temAMM_BAD_TOKENS`     | The specified `BidMin` or `BidMax` were not specified as the correct LP Tokens for this AMM. |
 | `temDISABLED`           | The AMM feature :not_enabled: is not enabled on this network. |
+| `temMALFORMED`          | The transaction specified invalid options, such as a list of `AuthAccounts` that is too long. |
 | `terNO_ACCOUNT`         | One of the accounts specified in this request do not exist. |
 | `terNO_AMM`             | The Automated Market Maker instance for the asset pair in this transaction does not exist. |
 

--- a/docs/xls-30d-amm/transaction-types/ammcreate.md
+++ b/docs/xls-30d-amm/transaction-types/ammcreate.md
@@ -61,14 +61,12 @@ Besides errors that can occur for all transactions, AMMCreate transactions can r
 |:--------------------|:---------------------------------------------|
 | `temDISABLED`       | The AMM feature :not_enabled: is not enabled on this network. |
 | `temINVALID_FLAG`   | The transaction specified an invalid `Flags` value. Since there are currently no flags defined for this transaction type, only [Global Flags](https://xrpl.org/transaction-common-fields.html#global-flags) are allowed. |
-| `temBAD_AMM_TOKENS` | The values of `Amount` and `Amount2` are not valid: for example, both refer to the same token. |
+| `temAMM_BAD_TOKENS` | The values of `Amount` and `Amount2` are not valid: for example, both refer to the same token. |
 | `temBAD_FEE`        | The `TradingFee` value is invalid. It must be zero or a positive integer and cannot be over 1000. |
-| `terNO_ACCOUNT`     | One of the accounts referenced in the request does not exist. |
-| `tecNO_AUTH`        | The sender is not authorized to hold one of the deposit assets (`Amount` or `Amount2`). |
-| `tecNO_LINE`        | The sender does not have a trust line for one of the deposit assets (`Amount` or `Amount2`). |
+| `tecINSUF_RESERVE_LINE` | The sender of this transaction does meet the increased [reserve requirement](https://xrpl.org/reserves.html) of processing this transaction, probably because they need a new trust line to hold the LP Tokens, and they don't have enough XRP to meet the additional owner reserve for a new trust line. |
 | `tecFROZEN`         | At least one of the deposit assets (`Amount` or `Amount2`) is currently [frozen](https://xrpl.org/freezes.html). |
-| `tecUNFUNDED_AMM`   | The sender does not hold enough money to fund the AMM with the amounts specified in `Amount` and `Amount2`. |
-| `tecAMM_EXISTS`     | There is already another AMM trading this currency pair. |
+| `tecAMM_UNFUNDED`   | The sender does not hold enough of the assets specified in `Amount` and `Amount2` to fund the AMM. |
+| `tecDUPLICATE`      | There is already another AMM for this currency pair. |
 
 <!--{# common link defs #}
 {% include '_snippets/rippled-api-links.md' %}

--- a/docs/xls-30d-amm/transaction-types/ammdeposit.md
+++ b/docs/xls-30d-amm/transaction-types/ammdeposit.md
@@ -117,16 +117,13 @@ Besides errors that can occur for all transactions, AMMDeposit transactions can 
 
 | Error Code              | Description                                  |
 |:------------------------|:---------------------------------------------|
-| `temBAD_AMM_OPTIONS`    | The transaction specified an invalid combination of fields. See [AMMDeposit Modes](#ammdeposit-modes). |
+| `temMALFORMED`          | The transaction specified an invalid combination of fields. See [AMMDeposit Modes](#ammdeposit-modes). |
 | `tecFROZEN`             | The transaction tried to deposit a [frozen](https://xrpl.org/freezes.html) token. |
 | `tecAMM_BALANCE`        | The AMM does not have enough of one of the assets to accept the deposit (for example, to satisfy the trade part of a single-asset deposit) or the sender does not have enough of a given token. |
-| `temBAD_AMM_TOKENS`     | The transaction specified the LP Tokens incorrectly; for example, the `issuer` is not the AMM's associated AccountRoot address or the `currency` is not the currency code for this AMM's LP Tokens, or the transaction specified this AMM's LP Tokens in one of the asset fields. |
+| `temAMM_BAD_TOKENS`     | The transaction specified the LP Tokens incorrectly; for example, the `issuer` is not the AMM's associated AccountRoot address or the `currency` is not the currency code for this AMM's LP Tokens, or the transaction specified this AMM's LP Tokens in one of the asset fields. |
 | `tecAMM_FAILED_DEPOSIT` | The conditions on the deposit could not be satisfied; for example, the requested effective price in the `EPrice` field is too low. |
-| `tecAMM_INVALID_TOKENS` | The AMM for this token pair does not exist, or one of the calculations resulted in a deposit amount rounding to zero. |
 | `tecINSUF_RESERVE_LINE` | The sender of this transaction does meet the increased [reserve requirement](https://xrpl.org/reserves.html) of processing this transaction, probably because they need a new trust line to hold the LP Tokens, and they don't have enough XRP to meet the additional owner reserve for a new trust line. |
-| `tecNO_AUTH`            | The sender is not authorized to hold one of the deposit assets. |
-| `tecNO_LINE`            | The sender does not have a trust line for one of the deposit assets. |
-| `tecUNFUNDED_AMM`       | The sender does not have a high enough balance to make the specified deposit. |
+| `tecAMM_UNFUNDED`       | The sender does not have a high enough balance to make the specified deposit. |
 | `terNO_ACCOUNT`         | An account specified in the request does not exist. |
 | `terNO_AMM`             | The Automated Market Maker instance for the asset pair in this transaction does not exist. |
 

--- a/docs/xls-30d-amm/transaction-types/ammvote.md
+++ b/docs/xls-30d-amm/transaction-types/ammvote.md
@@ -51,7 +51,6 @@ Besides errors that can occur for all transactions, AMMVote transactions can res
 |:------------------------|:---------------------------------------------|
 | `tecAMM_INVALID_TOKENS` | The sender cannot vote because they do not hold any of this AMM's LP Tokens. |
 | `tecAMM_FAILED_VOTE`    | There are already 8 votes from accounts that hold more LP Tokens than the sender of this transaction. |
-| `terNO_ACCOUNT`         | An account specified in this transaction does not exist. |
 | `temBAD_FEE`            | The `TradingFee` from this transaction is not valid. |
 | `terNO_AMM`             | The Automated Market Maker instance for the asset pair in this transaction does not exist. |
 

--- a/docs/xls-30d-amm/transaction-types/ammwithdraw.md
+++ b/docs/xls-30d-amm/transaction-types/ammwithdraw.md
@@ -57,7 +57,7 @@ In addition to the common fields, AMMWithdraw transactions use the following fie
 This transaction has several modes, depending on which flags you specify. Each mode expects a specific combination of fields. The modes fall into two categories:
 
 - **Double-asset withdrawals**, in which you receive both assets from the AMM's pool in proportions that match their balances there. These withdrawals are not subject to a fee.
-- **Single-asset withdrawals**, in which you receive one asset from the AMM's pool. The AMM charges a fee based on how much your deposit shifts the balance of assets in the pool. Depending on the withdraw mode, the amount of the fee can be added to the amount of LP Tokens paid in, or debited from the amount of the asset paid out.
+- **Single-asset withdrawals**, in which you receive one asset from the AMM's pool. The AMM charges a fee based on how much your withdrawal shifts the balance of assets in the pool. Depending on the withdraw mode, the amount of the fee can be added to the amount of LP Tokens paid in, or debited from the amount of the asset paid out.
 
 The following modes are for a **double-asset withdrawal**:
 
@@ -108,14 +108,14 @@ Besides errors that can occur for all transactions, {{currentpage.name}} transac
 
 | Error Code               | Description                                  |
 |:-------------------------|:---------------------------------------------|
-| `tecFROZEN`              | The transaction tried to deposit a [frozen](https://xrpl.org/freezes.html) token. |
+| `tecFROZEN`              | The transaction tried to withdraw a [frozen](https://xrpl.org/freezes.html) token. |
 | `tecAMM_BALANCE`         | The transaction would withdraw all of one asset from the pool, or rounding would cause a "withdraw all" to leave a nonzero amount behind. |
 | `tecAMM_FAILED_WITHDRAW` | The conditions on the withdrawal could not be satisfied; for example, the requested effective price in the `EPrice` field is too low. |
 | `tecAMM_INVALID_TOKENS`  | The AMM for this token pair does not exist, or one of the calculations resulted in a withdrawal amount rounding to zero. |
 | `tecINSUF_RESERVE_LINE`  | The sender of this transaction does not meet the increased [reserve requirement](https://xrpl.org/reserves.html) of processing this transaction, probably because they need at least one new trust line to hold one of the assets to be withdrawn, and they don't have enough XRP to meet the additional owner reserve for a new trust line. |
-| `tecNO_AUTH`             | The sender is not authorized to hold one of the deposit assets. |
-| `temBAD_AMM_OPTIONS`     | The transaction specified an invalid combination of fields. See [AMMWithdraw Modes](#ammwithdraw-modes). |
-| `temBAD_AMM_TOKENS`      | The transaction specified the LP Tokens incorrectly; for example, the `issuer` is not the AMM's associated AccountRoot address or the `currency` is not the currency code for this AMM's LP Tokens, or the transaction specified this AMM's LP Tokens in one of the asset fields.  |
+| `tecNO_AUTH`             | The sender is not authorized to hold one of the AMM assets. |
+| `temMALFORMED`           | The transaction specified an invalid combination of fields. See [AMMWithdraw Modes](#ammwithdraw-modes). |
+| `temAMM_BAD_TOKENS`      | The transaction specified the LP Tokens incorrectly; for example, the `issuer` is not the AMM's associated AccountRoot address or the `currency` is not the currency code for this AMM's LP Tokens, or the transaction specified this AMM's LP Tokens in one of the asset fields.  |
 | `terNO_AMM`              | The Automated Market Maker instance for the asset pair in this transaction does not exist. |
 
 

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -52,6 +52,7 @@ opensource:
             expanded: false
             pages:
               - page: docs/xls-30d-amm/ledger-object-types/amm.md
+              - page: docs/xls-30d-amm/ledger-object-types/accountroot.md
           - group: Transaction Types
             expanded: false
             pages:
@@ -60,7 +61,9 @@ opensource:
               - page: docs/xls-30d-amm/transaction-types/ammdeposit.md
               - page: docs/xls-30d-amm/transaction-types/ammvote.md
               - page: docs/xls-30d-amm/transaction-types/ammwithdraw.md
+          - page: docs/xls-30d-amm/transaction-result-codes/index.md
           - group: Public API Methods
             expanded: false
             pages:
               - page: docs/xls-30d-amm/public-api-methods/amm_info.md
+              - page: docs/xls-30d-amm/public-api-methods/ledger_entry.md


### PR DESCRIPTION
Corresponding PRs from the xrpl-dev-portal repo:

- Remove files there that are added here: https://github.com/XRPLF/xrpl-dev-portal/pull/1874
- Updating AMM error codes: https://github.com/XRPLF/xrpl-dev-portal/pull/1837/

Note: this PR does not include the Japanese translations, because we are waiting for some advice from Redocly on how best to present multiple languages. The plan is to add those back soon.