### PR TITLE
Update caution to a note reflecting current implementation

### DIFF
--- a/docs/xls-38d-cross-chain-bridge/transaction-types/xchaincreatebridge.md
+++ b/docs/xls-38d-cross-chain-bridge/transaction-types/xchaincreatebridge.md
@@ -14,16 +14,11 @@ status: not_enabled
 
 The `XChainCreateBridge` transaction creates a new `Bridge` ledger object and defines a new cross-chain bridge entrance on the chain that the transaction is submitted on. It includes information about door accounts and assets for the bridge. 
 
-The transaction must be submitted by the door account. To set up a valid bridge, door accounts on both chains must submit this transaction, in addition to setting up witness servers.
+The transaction must be submitted first by the locking chain door account. To set up a valid bridge, door accounts on both chains must submit this transaction, in addition to setting up witness servers.
 
 The complete production-grade setup would also include a `SignerListSet` transaction on the two door accounts for the witnesses’ signing keys, as well as disabling the door accounts’ master key. This ensures that the witness servers are truly in control of the funds.
 
-**Caution:** Ensure that you do not create a duplicate bridge with different set of door accounts for an existing asset. Doing so can cause an imbalance of available wrapped XRP on the issuing chain. 
-
-To mitigate the possibility of creating a duplicate bridge, ensure the following:
-
-* The issuing chain door account should only issue tokens for a single bridge. Do not create two(2) bridges with the same issuing asset on the same issuing chain. 
-* Do not create two (2) bridges with the same locking asset in the same door account. You can create them with different door accounts. 
+**Note:** Each door account can only have one bridge. This prevents the creation of duplicate bridges for the same asset, which can cause asset imbalances on either chain.
 
 
 ## Example XChainCreateBridge JSON


### PR DESCRIPTION
Door accounts can only have one bridge by default. Updated note to reflect this behavior and explain why.