### PR TITLE
Use gtag instead of ga for analytics

### DIFF
--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -26,11 +26,14 @@ copyCodeSnippet:
 stylesheets:
   - ./static/style.css
   - ./static/fonts.css
+# https://redocly.com/docs/developer-portal/configuration/siteconfig/analytics/#google-global-site-tag-gtagjs
 analytics:
-  ga:
-  # note that GA doesn't work in the development environment
-    head: true
-    trackingId: G-S1KBMRJYKS
+  gtag:
+    # note that GA doesn't work in the development environment
+    trackingIds:
+        - "G-S1KBMRJYKS" #Google Analytics / GA
+    pluginConfig:
+      head: true
 #scripts:
 #  - ./static/intercom.js
 nav:


### PR DESCRIPTION
`gtag` is apparently the more up to date version of google analytics, so should add the necessary script to each page. 

Documentation: 
1. General config: https://redocly.com/docs/developer-portal/configuration/siteconfig/analytics/#google-global-site-tag-gtagjs
2. This guide to go from `ga` to `gtag` makes me think that `gtag` is the proper one to use because the `gtag` snippet looks like the one we want to add, and the `ga` snippet looks like the one we added which didn't work. https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs

I also added links to the docs in order to make it easier to update later if people wondered where to look up the configuration options.