### PR TITLE
Fix typo in AMM ledger_entry API example

### DIFF
--- a/docs/xls-30d-amm/public-api-methods/ledger_entry.md
+++ b/docs/xls-30d-amm/public-api-methods/ledger_entry.md
@@ -25,7 +25,7 @@ Retrieve an Automated Market-Maker (AMM) object from the ledger. This is similar
       "currency" : "TST",
       "issuer" : "rP9jPyP5kyvFRb6ZiRghAGw5u8SGAmU4bd"
     }
-  }
+  },
   "ledger_index": "validated"
 }
 ```


### PR DESCRIPTION
The `amm_info` request was missing a comma - this adds it back :) 

(Confirmed this new transaction was well-formed using the Websocket API tool)

![image](https://github.com/ripple/opensource.ripple.com/assets/19694186/bef95c27-32b9-470c-8c1d-b422784c1808)
