### PR TITLE
Remove flags from AMMCreate example transaction

### DIFF
--- a/docs/xls-30d-amm/transaction-types/ammcreate.md
+++ b/docs/xls-30d-amm/transaction-types/ammcreate.md
@@ -31,7 +31,7 @@ Creates both an [AMM object](../ledger-object-types/amm.md) and a [special Accou
     },
     "Amount2" : "250000000",
     "Fee" : "10",
-    "Flags" : 2147483648,
+    "Flags" : 0,
     "Sequence" : 6,
     "TradingFee" : 500,
     "TransactionType" : "AMMCreate"


### PR DESCRIPTION
AMMCreate has no valid flags currently (at least according to the `temINVALID_FLAG` error code description, so the example should have flags set to 0. 

Feel free to modify / merge / close at will.