### PR TITLE
Update more AMM details

### DIFF
--- a/docs/xls-30d-amm/transaction-types/ammcreate.md
+++ b/docs/xls-30d-amm/transaction-types/ammcreate.md
@@ -46,7 +46,7 @@ In addition to the common fields, AMMCreate transactions use the following field
 | `Amount2`    | [Currency Amount][] | Amount            | Yes       | The second of the two assets to fund this AMM with. This must be a positive amount. |
 | `TradingFee` | Number              | UInt16            | Yes       | The fee to charge for trades against this AMM instance, in units of 1/100,000; a value of 1 is equivalent to 0.001%. The maximum value is `1000`, indicating a 1% fee. The minimum value is `0`. |
 
-One or both of `Amount` and `Amount2` can be [tokens](https://xrpl.org/tokens.html); at most one of them can be [XRP](https://xrpl.org/xrp.html). They cannot both have the same currency code and issuer. An AMM's LP tokens _can_ be used as one of the assets for another AMM.
+One or both of `Amount` and `Amount2` can be [tokens](https://xrpl.org/tokens.html); at most one of them can be [XRP](https://xrpl.org/xrp.html). They cannot both have the same currency code and issuer. The tokens' issuers must have [Default Ripple](https://xrpl.org/rippling.html#the-default-ripple-flag) enabled. If the Clawback amendment is enabled, those issuers must not have the ability to clawback their tokens. An AMM's LP tokens _can_ be used as one of the assets for another AMM.
 
 ## Error Cases
 

--- a/snippets/_amm-disclaimer.md
+++ b/snippets/_amm-disclaimer.md
@@ -1,3 +1,3 @@
 :::attention Attention
 
-_Automated Market Maker (AMM) functionality is part of the proposed [XLS-30d](https://github.com/XRPLF/XRPL-Standards/discussions/78) extension to the XRP Ledger protocol. You can use these functions on AMM test networks, but there isn't an official amendment and they aren't available on the production Mainnet. Until there is an amendment, the details documented on these pages are subject to change._ <!-- SPELLING_IGNORE: 30d -->
+_Automated Market Maker (AMM) functionality is part of the proposed [XLS-30d](https://github.com/XRPLF/XRPL-Standards/discussions/78) extension to the XRP Ledger protocol. You can use these functions on test networks for now. Until there is an amendment in a stable release, the details documented on these pages are subject to change._ <!-- SPELLING_IGNORE: 30d -->


### PR DESCRIPTION
Largely documents the changes from https://github.com/XRPLF/rippled/pull/4626

- Remove lsfAMM flag, add AMMID field to AccountRoot
- Clarify new and existing limitations on AMM AccountRoot entries
- Update a couple other details (e.g. there is an "AMM" amendment in the develop branch now, but it's still subject to change until release.)