### PR TITLE
docs: rename `AMMAccount` to `Account` for `AMM`

### DIFF
--- a/docs/xls-30d-amm/ledger-object-types/amm.md
+++ b/docs/xls-30d-amm/ledger-object-types/amm.md
@@ -20,7 +20,7 @@ The `AMM` object type describes a single [Automated Market Maker](../automated-m
 
 ```json
 {
-    "AMMAccount" : "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
+    "Account" : "rE54zDvgnghAoPopCgvtiqWNq3dU5y836S",
     "Asset" : {
       "currency" : "XRP"
     },
@@ -77,7 +77,7 @@ The `AMM` object has the following fields:
 |:-----------------|:--------------------|:------------------|:----------|--------------|
 | `Asset`          | Object              | STIssue           | Yes       | The definition for one of the two assets this AMM holds. In JSON, this is an object with `currency` and `issuer` fields. |
 | `Asset2`         | Object              | STIssue           | Yes       | The definition for the other asset this AMM holds. In JSON, this is an object with `currency` and `issuer` fields. |
-| `AMMAccount`     | String              | AccountID         | Yes       | The address of the [special account](https://xrpl.org/accountroot.html#special-amm-accountroot-objects) that holds this AMM's assets. |
+| `Account`        | String              | AccountID         | Yes       | The address of the [special account](https://xrpl.org/accountroot.html#special-amm-accountroot-objects) that holds this AMM's assets. |
 | `AuctionSlot`    | Object              | STObject          | No        | Details of the current owner of the auction slot, as an [Auction Slot object](#auction-slot-object). |
 | `LPTokenBalance` | [Currency Amount][] | Amount            | Yes       | The total outstanding balance of liquidity provider tokens from this AMM instance. The holders of these tokens can vote on the AMM's trading fee in proportion to their holdings, or redeem the tokens for a share of the AMM's assets which grows with the trading fees collected. |
 | `TradingFee`     | Number              | UInt16            | Yes       | The percentage fee to be charged for trades against this AMM instance, in units of 1/100,000. The maximum value is 1000, for a 1% fee. |


### PR DESCRIPTION
The correct field for an `AMM` ledger object is `Account`.

## Context of Change

A while ago I created a ticket (https://github.com/ripple/explorer/issues/734).  Turns out the code for showing a link to the AMM account page already existed but the property in the meta was not the same as is in the unit tests,

We were checking for `AMMAccount` on an `AMM` ledger object in a transaction's meta data. Upon viewing this [transaction](http://localhost:3001/transactions/DCD3DA3A82954C1A0C5FE21092A9F400B28709752F1AD95676B04A321CD66A75/raw) I saw that the property is `Account`.

Another Example: https://xrpl.org/websocket-api-tool.html?server=wss%3A%2F%2Famm.devnet.rippletest.net%3A51233%2F&req=%7B%22command%22%3A%22ledger_entry%22%2C%22index%22%3A%22526E82EAE65D52387843D532CC1EB3F435E6DA66439C5AA368D19E219C7DED66%22%2C%22ledger_index%22%3A%22validated%22%7D