### PR TITLE
Update Sidechain network name

### DIFF
--- a/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain.md
+++ b/docs/evm-sidechain/connect-metamask-to-xrpl-evm-sidechain.md
@@ -43,7 +43,7 @@ To add XRP Ledger EVM Sidechain to MetaMask:
 
 3. Enter the XRP Ledger Devnet endpoint information.
 
-    * **Network Name**: XRPL EVM Sidechain
+    * **Network Name**: XRPL EVM Sidechain Devnet
     * **New RPC URL**: https://rpc-evm-sidechain.xrpl.org
     * **Chain ID**: 1440002
     * **Currency Symbol**: XRP


### PR DESCRIPTION
The XRP Ledger EVM Sidechain's Network Name should be updated to clarify that it is on `Devnet`. This reflects the naming used when setting up the chain via the Bridge too, and will ensure consistency for new developers joining the ecosystem.