### PR TITLE
Update call-a-smart-contract-function.md

### DIFF
--- a/docs/axelar/call-a-smart-contract-function.md
+++ b/docs/axelar/call-a-smart-contract-function.md
@@ -69,7 +69,7 @@ This example calls the `ExecutableSample` contract from XRPL to update its `mess
         const paymentTx: xrpl.Transaction = {
             TransactionType: "Payment",
             Account: user.address,
-            Amount: xrpl.xrpToDrops(1),
+            Amount: "1",
             Destination: "rfEf91bLxrTVC76vw1W3Ur8Jk4Lwujskmb",
             SigningPubKey: "",
             Flags: 0,


### PR DESCRIPTION
remove xrp to drop conversion. instructions state to send one drop but 1 xrp was being converted to 1m drops