### PR TITLE
Update Axelar Bridge docs

### DIFF
--- a/docs/axelar/bridge-tokens-axelar.md
+++ b/docs/axelar/bridge-tokens-axelar.md
@@ -8,11 +8,11 @@ This tutorial describes how to transfer tokens between Ethereum `Sepolia` and th
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- [XRPL.js Library](https://js.xrpl.org/)
 - An RPC provider, such as Alchemy or Infura, with the `SEPOLIA_RPC_URL` environment variable set to a working `Sepolia` RPC URL.
 - Funded wallets on both chains.
   - **ETH Sepolia Faucet:** [alchemy.com/faucets/ethereum-sepolia](https://www.alchemy.com/faucets/ethereum-sepolia)
   - **XRPL Testnet Faucet:** [faucet.tequ.dev](https://faucet.tequ.dev/)
-- [XRPL JS Library](https://js.xrpl.org/)
 
 
 ## Bridge ETH

--- a/docs/axelar/call-a-smart-contract-function.md
+++ b/docs/axelar/call-a-smart-contract-function.md
@@ -41,14 +41,14 @@ This tutorial describes how to call a function from a smart contract on Ethereum
     AXELAR_EXECUTABLE= # your `AxelarExecutable` contract
     COMMAND_ID= # the `commandId` that was emitted in the `ContractCallApproved` event
     SOURCE_ADDRESS= # the XRPL address that performed the `Payment` deposit transaction
-    PAYLOAD= # abi.encode(['string', 'uint256', 'bytes'], [symbol, amount, gmpPayload])
+    PAYLOAD= # abi.encode(['string', 'uint256', 'bytes'], [denom, amount, gmpPayload]) # `denom` is `uxrp` for XRP and `uweth` for WETH
     cast send $AXELAR_EXECUTABLE 'function execute(bytes32 commandId, string calldata sourceChain, string calldata sourceAddress, bytes calldata payload)' $COMMAND_ID xrpl $SOURCE_ADDRESS $PAYLOAD --private-key $PRIVATE_KEY --rpc-url $SEPOLIA_RPC_URL
     ```
 
 
 ## Example GMP Call
 
-We have created and [deployed to Ethereum Sepolia](https://sepolia.etherscan.io/address/0x189C2572063f25FEf5Cdd3516DDDd9fA6e9CB187) an example `AxelarExecutable` contract called [`ExecutableSample`](https://github.com/commonprefix/axelar-xrpl-solidity/blob/main/src/executable/examples/ExecutableSample.sol).
+We have created and [deployed to Ethereum Sepolia](https://sepolia.etherscan.io/address/0x143669292488bd98a0F14F1c73829572f2c25773) an example `AxelarExecutable` contract called [`ExecutableSample`](https://github.com/commonprefix/axelar-xrpl-solidity/blob/main/src/executable/examples/ExecutableSample.sol).
 
 This example calls the `ExecutableSample` contract from XRPL to update its `message` state variable to `Just transferred XRP to Ethereum!`.
 
@@ -77,7 +77,7 @@ This example calls the `ExecutableSample` contract from XRPL to update its `mess
             Memos: [
                 {
                     Memo: {
-                        MemoData: "189C2572063f25FEf5Cdd3516DDDd9fA6e9CB187", // the `ExecutableSample` contract
+                        MemoData: "143669292488bd98a0F14F1c73829572f2c25773", // the `ExecutableSample` contract
                         MemoType: Buffer.from("destination_address").toString('hex').toUpperCase(),
                     },
                 },
@@ -89,7 +89,7 @@ This example calls the `ExecutableSample` contract from XRPL to update its `mess
                 },
                 {
                     Memo: {
-                        MemoData: "df031b281246235d0e8c8254cd731ed95d2caf4db4da67f41a71567664a1fae8", // keccak256(abi.encode(gmpPayload))
+                        MemoData: "df031b281246235d0e8c8254cd731ed95d2caf4db4da67f41a71567664a1fae8", // keccak256(abi.encode(gmpPayload)), in this example, keccak256(abi.encode(['string'], ['Just transferred XRP to Ethereum!']))
                         MemoType: Buffer.from("payload_hash").toString('hex').toUpperCase(),
                     },
                 },
@@ -110,17 +110,17 @@ This example calls the `ExecutableSample` contract from XRPL to update its `mess
 3. Call the `ExecutableSample.execute()`.
 
     ```sh
-    AXELAR_EXECUTABLE=0x189C2572063f25FEf5Cdd3516DDDd9fA6e9CB187
+    AXELAR_EXECUTABLE=0x143669292488bd98a0F14F1c73829572f2c25773
     COMMAND_ID= # the `commandId` that was emitted in the `ContractCallApproved` event
     SOURCE_ADDRESS= # the XRPL address of the `user` who performed the `Payment` deposit transaction
-    PAYLOAD=000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000661786c58525000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000214a757374207472616e736665727265642058525020746f20457468657265756d2100000000000000000000000000000000000000000000000000000000000000 # encode(['string', 'uint256', 'bytes'], [symbol, amount, encode(['string'], ['Just transferred XRP to Ethereum!'])])
+    PAYLOAD=000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000661786c58525000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000214a757374207472616e736665727265642058525020746f20457468657265756d2100000000000000000000000000000000000000000000000000000000000000 # encode(['string', 'uint256', 'bytes'], [denom, amount, encode(['string'], ['Just transferred XRP to Ethereum!'])]) # `denom` is `uxrp` for XRP and `uweth` for WETH
     cast send $AXELAR_EXECUTABLE 'function execute(bytes32 commandId, string calldata sourceChain, string calldata sourceAddress, bytes calldata payload)' $COMMAND_ID xrpl $SOURCE_ADDRESS $PAYLOAD --private-key $PRIVATE_KEY --rpc-url $SEPOLIA_RPC_URL
     ```
 
 4. `AxelarExecutable.message` should now be set to `'Just transferred XRP to Ethereum!'`.
 
     ```sh
-    AXELAR_EXECUTABLE=0x189C2572063f25FEf5Cdd3516DDDd9fA6e9CB187
+    AXELAR_EXECUTABLE=0x143669292488bd98a0F14F1c73829572f2c25773
     cast call $AXELAR_EXECUTABLE 'message()(string)' --rpc-url $SEPOLIA_RPC_URL
     # Just transferred XRP to Ethereum!
     ```

--- a/docs/axelar/intro-to-axelar.md
+++ b/docs/axelar/intro-to-axelar.md
@@ -1,6 +1,6 @@
 # Axelar Network
 
-The [Axelar network](https://www.axelar.network/) is a Web3 interoperability platform, acting as a bridge between blockchains. The XRPL-Axelar integration enables the transfer of XRP and XRPL-issued tokens to other chains, and the transfer of tokens from other chains (such as ERC-20 tokens) to the XRPL.
+The [Axelar network](https://www.axelar.network/) is a Web3 interoperability platform, acting as a bridge between blockchains. The XRPL-Axelar integration enables the transfer of XRP and XRPL-issued tokens to other chains, and the transfer of tokens from other chains (such as ERC-20 tokens) to the XRPL. The integration additionally enables performing [general message passing (GMP) calls](https://www.axelar.network/blog/general-message-passing-and-how-can-it-change-web3) *from* the XRPL, i.e., calling smart contracts that live on Axelar-supported chains from XRPL.
 
 At a high level, the bridging process is fairly simple.
 


### PR DESCRIPTION
"Call a Smart Contract Function" page changes:
- Point to new `ExecutableSample` contract deployment
- Re-name `symbol` to `denom`
- Provide example for ambiguous `abi.encode(gmpPayload)`
- Use xrpl.js instead of eth-py
- Re-arrange payload-construction comments

"Bridge Tokens" page changes:
- Rename "XRPL JS" to "XRPL.js" for consistency

"Axelar Bridge" page changes:
- Mention GMP capability, besides just token transfers