### PR TITLE
Improved table UI in LedgerStateFix

### DIFF
--- a/docs/ledger-state-fix/index.md
+++ b/docs/ledger-state-fix/index.md
@@ -1,17 +1,19 @@
 ---
 seo:
-    description: Repair corruptions to the XRP ledger.
+  description: Repair corruptions to the XRP ledger.
 labels:
   - Utilities, troubleshooting
 ---
+
 # LedgerStateFix
+
 [[Source]](https://github.com/XRPLF/rippled/blob/develop/src/xrpld/app/tx/detail/LedgerStateFix.cpp "Source")
 
 {% partial file="/snippets/_ledgerstatefix-disclaimer.md" /%}
 
-`LedgerStateFix` is a general purpose transaction used to fix specific issues affecting the XRP ledger. You submit the transaction with the `LedgerFixType` value set to indicate the particular  error state to correct.
+`LedgerStateFix` is a general purpose transaction used to fix specific issues affecting the XRP ledger. You submit the transaction with the `LedgerFixType` value set to indicate the particular error state to correct.
 
-_(Added by the [NonFungibleTokensV1_1](https://xrpl.org/resources/known-amendments#nonfungibletokensv1_1) amendment.
+\_(Added by the [NonFungibleTokensV1_1](https://xrpl.org/resources/known-amendments#nonfungibletokensv1_1) amendment.
 
 ## Example LedgerStateFix JSON
 
@@ -28,15 +30,54 @@ _(Added by the [NonFungibleTokensV1_1](https://xrpl.org/resources/known-amendmen
 }
 ```
 
-
-| Field | Data Type  | Required? | Description |
-|:------|:-----------|:----------|:------------|
-| `TransactionType` | uint16 | Required | Identifies this as a `LedgerStateFix` transaction. |
-| `Account` | STAccount | Required | Identifies the account signing and submitting the transaction as well as paying the Fee. |
-| `Fee` | STAmount | Required | This transaction is rare and potentially compute intensive. The minimum fee is the same as the fee for an AccountDelete transaction. If the transaction fails with a tec code, the fee is still charged. |
-| `Flags` | uint32 | Optional | Not needed for `LedgerFixType` == _1_. Reserved for a future type of ledger fix. |
-| `LedgerFixType` | uint16 | Required | Currently the only type is _1_, which fixes the NFToken directory for a single account. |
-| `Owner` | STAccount | Optional | Required if `LedgerFixType` == _1_, the account ID that owns the NFToken directory that needs fixing. Need not have any relationship to Account. |
+<table>
+  <thead>
+    <tr>
+      <th style="width: 20%; text-align: left;">Field</th>
+      <th style="width: 20%; text-align: left;">Data Type</th>
+      <th style="width: 10%; text-align: left;">Required?</th>
+      <th style="width: 50%; text-align: left;">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>TransactionType</code></td>
+      <td>uint16</td>
+      <td>Required</td>
+      <td>Identifies this as a <code>LedgerStateFix</code> transaction.</td>
+    </tr>
+    <tr>
+      <td><code>Account</code></td>
+      <td>STAccount</td>
+      <td>Required</td>
+      <td>Identifies the account signing and submitting the transaction as well as paying the Fee.</td>
+    </tr>
+    <tr>
+      <td><code>Fee</code></td>
+      <td>STAmount</td>
+      <td>Required</td>
+      <td>This transaction is rare and potentially compute intensive. The minimum fee is the same as the fee for an AccountDelete transaction. If the transaction fails with a tec code, the fee is still charged.</td>
+    </tr>
+    <tr>
+      <td><code>Flags</code></td>
+      <td>uint32</td>
+      <td>Optional</td>
+      <td>Not needed for <code>LedgerFixType</code> == _1_. Reserved for a future type of ledger fix.</td>
+    </tr>
+    <tr>
+      <td><code>LedgerFixType</code></td>
+      <td>uint16</td>
+      <td>Required</td>
+      <td>Currently the only type is _1_, which fixes the NFToken directory for a single account.</td>
+    </tr>
+    <tr>
+      <td><code>Owner</code></td>
+      <td>STAccount</td>
+      <td>Optional</td>
+      <td>Required if <code>LedgerFixType</code> == _1_, the account ID that owns the NFToken directory that needs fixing. Need not have any relationship to Account.</td>
+    </tr>
+  </tbody>
+</table>
 
 ## LedgerStateFix Flags
 
@@ -44,7 +85,7 @@ Transactions of the LedgerStateFix type can support additional values in the `Fl
 
 ## Error Cases
 
-Potential errors are those that can occur for all transactions. {% $frontmatter.seo.title %}. 
+Potential errors are those that can occur for all transactions. {% $frontmatter.seo.title %}.
 
 ## LedgerStateFix Types
 


### PR DESCRIPTION
In the opensource.ripple.com/docs/ledger-state-fix/index.md file, table data under the "Field" header was previously breaking into multiple lines within small containers. This update ensures the field names now stay on a single line, improving table readability and aesthetics.