### PR TITLE
Add link to High vs Low topic in RippleState topic.

### DIFF
--- a/docs/xls-77d-deep-freeze/deep-freeze.md
+++ b/docs/xls-77d-deep-freeze/deep-freeze.md
@@ -39,6 +39,8 @@ Deep Freeze introduces two flags, `lsfLowDeepFreeze` and `lsfHighDeepFreeze`, in
 | `lsfLowDeepFreeze`	| `0x02000000`	| The low account has deep-frozen the trust line, preventing the high account from sending and receiving the asset. |
 | `lsfHighDeepFreeze`	| `0x04000000`	| The high account has deep-frozen the trust line, preventing the low account from sending and receiving the asset. |
 
+See [High vs. Low Account](https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate#high-vs.-low-account).
+
 ### TrustSet Transaction
 
 Deep Freeze introduces two flags, `tfSetDeepFreeze` and `tfClearDeepFreeze`, in the `TrustSet` transaction.


### PR DESCRIPTION
Adding a hyperlink to the docs for High vs Low Account in context of the high/low deep freeze flag settings.