### PR TITLE
Bump Redocly to Realm v0.118.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@redocly/realm": "^0.115.0",
+        "@redocly/realm": "^0.118.2",
         "@redocly/theme": "^0.50.0"
       }
     },
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.1.tgz",
-      "integrity": "sha512-3rA9lcwciEB47ZevqvD8qgbzhM9qMb8vCcQCNmDfVRPQG4JT9mSb0Jg8H7YjKGGQcFnLN323fj9jdnG59Kx6bg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -538,15 +538,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
@@ -1734,6 +1725,31 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@redocly/config": {
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.3.tgz",
+      "integrity": "sha512-Nyyv1Bj7GgYwj/l46O0nkH1GTKWbO3Ixe7KFcn021aZipkZd+z8Vlu1BwkhqtVgivcKaClaExtWU/lDHkjBzag==",
+      "license": "MIT"
+    },
+    "node_modules/@redocly/graphql-docs": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.7.16.tgz",
+      "integrity": "sha512-xW+VeEfkxNW9b1tyuoZQBm3nJhLSV48CNe+/qQZbA8Ba8GpR9I8+Pz76FVlAwxqOFBpeGrBlxA6mTdElTlPX1w==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@redocly/config": "0.20.3",
+        "deepmerge": "^4.2.2",
+        "marked": "^4.0.15"
+      },
+      "peerDependencies": {
+        "@redocly/theme": "^0.50.0",
+        "graphql": "^16.9.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.21.1",
+        "styled-components": "^5.3.11"
+      }
+    },
     "node_modules/@redocly/mock-server": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@redocly/mock-server/-/mock-server-0.2.5.tgz",
@@ -1780,103 +1796,37 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@redocly/mock-server/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@redocly/mock-server/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server": {
-      "version": "0.3.71",
-      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.3.71.tgz",
-      "integrity": "sha512-od/ulAT8ZoSs8ucY4vY/WjQAeoMaGoIBudht51j7e72ckmMt5Ltd9ozShDgkrT300Z6675rP1SUNEQ+wGnlo2A==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.20.1",
-        "@redocly/mock-server": "0.2.5",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/openapi-docs": "3.5.19"
-      }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/config": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.1.tgz",
-      "integrity": "sha512-TYiTDtuItiv95YMsrRxyCs1HKLrDPtTvpaD3+kDKXBnFDeJuYKZ+eHXpCr6YeN4inxfVBs7DLhHsQcs9srddyQ==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/openapi-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.27.1.tgz",
-      "integrity": "sha512-zQ47/A+Drk2Y75/af69MD3Oad4H9LxkUDzcm7XBkyLNDKIWQrDKDnS5476oDq77+zciymNxgMVtxxVXlnGS8kw==",
+    "node_modules/@redocly/openapi-core": {
+      "version": "0.0.0-snapshot.1737556585",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-0.0.0-snapshot.1737556585.tgz",
+      "integrity": "sha512-ejUeEffXcSKA3GeLJApRQcL1UXJV2ZJ/Pt0/b/v17E/IAV2CFiwcG5OhtMvZDiTYd3v4/1YgJrmiwLDZ6u4W0g==",
       "license": "MIT",
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.17.0",
+        "@redocly/config": "^0.20.1",
         "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
         "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
       "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
+        "node": ">=18.17.0",
+        "npm": ">=10.8.2"
       }
     },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.17.1.tgz",
-      "integrity": "sha512-CEmvaJuG7pm2ylQg53emPmtgm4nW2nxBgwXzbVEHpGas/lGnMyN8Zlkgiz6rPw0unASg6VW3wlz27SOL5XFHYQ==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/openapi-docs": {
-      "version": "3.5.19",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.5.19.tgz",
-      "integrity": "sha512-E+tttuJHEF1adybM9VlMs42nZKv7N8alwDJe4ZkA/BbwQXE1Pk9/QhJvW7I8ZrMCcYKBhDcotVhsiFukzfuptA==",
+    "node_modules/@redocly/openapi-docs": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.6.3.tgz",
+      "integrity": "sha512-0VUeUfHwrICnSE4L9JN3Iat1s5rasMINgVVS2GGLz+S018wt/aghQMB56iezO/zMThVNNylVTut/KhgfPjMCdg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@markdoc/markdoc": "0.4.0",
-        "@redocly/config": "0.20.1",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/replay": "0.9.1",
+        "@redocly/config": "0.20.3",
+        "@redocly/openapi-core": "0.0.0-snapshot.1737556585",
+        "@redocly/replay": "0.9.6",
         "deepmerge": "^4.2.2",
         "dompurify": "2.5.4",
         "fast-deep-equal": "^3.1.3",
@@ -1911,91 +1861,22 @@
         "styled-components": "^4.1.1 || ^5.3.11"
       }
     },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/replay": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.9.1.tgz",
-      "integrity": "sha512-axY7rcpF92v40qjWZSziQ6ehLhg19uqChBiSMo1DY2tlUmMpVY3hj0TuDfUY21tWO+jm7CAHm6XRFsROpvw1mQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.15.0",
-        "@codemirror/lang-html": "^6.4.7",
-        "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-xml": "^6.0.2",
-        "@codemirror/lint": "^6.5.0",
-        "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.25.1",
-        "@hookstate/core": "^4.0.1",
-        "@hookstate/devtools": "^4.0.1",
-        "@hookstate/localstored": "^4.0.1",
-        "@lezer/highlight": "^1.1.6",
-        "@redocly/vscode-json-languageservice": "^3.4.9",
-        "@tauri-apps/plugin-dialog": "2.0.0-beta.7",
-        "@tauri-apps/plugin-fs": "2.0.0-beta.8",
-        "@uiw/codemirror-theme-material": "^4.21.20",
-        "@uiw/react-codemirror": "^4.21.20",
-        "crypto-js": "^4.2.0",
-        "dayjs": "^1.11.7",
-        "js-yaml": "4.1.0",
-        "marked": "^4.0.15",
-        "rc-tooltip": "^6.1.3",
-        "react-resizable-panels": "^1.0.9",
-        "react-select": "5.8.1",
-        "styled-components": "^5.3.11"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "0.48.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^5.3.11"
-      }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/@redocly/theme": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.48.1.tgz",
-      "integrity": "sha512-UrleXuk+/bRpF8cpqXVY4EFA+HUcVJ6+9Ii5b2FsAMNjENWSUSQeXhombF+H7LKQJHpAUa72qByUTYpcwXgqfA==",
+    "node_modules/@redocly/portal-plugin-mock-server": {
+      "version": "0.3.76",
+      "resolved": "https://registry.npmjs.org/@redocly/portal-plugin-mock-server/-/portal-plugin-mock-server-0.3.76.tgz",
+      "integrity": "sha512-vpM/khErsWWZSFJScB6Smj/wYRUhy3B2vQFf32APEkfwlhDEzw98M38voIYZFLrR6JejUYYHIQCkgnHwjBmEVg==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
-        "@redocly/config": "0.20.1",
-        "copy-to-clipboard": "3.3.3",
-        "file-saver": "2.0.5",
-        "highlight-words-core": "1.2.2",
-        "hotkeys-js": "3.10.1",
-        "i18next": "22.4.15",
-        "jszip": "3.10.1",
-        "nprogress": "0.2.0",
-        "react-calendar": "4.2.1",
-        "react-date-picker": "10.0.3",
-        "timeago.js": "4.0.2"
-      },
-      "peerDependencies": {
-        "@markdoc/markdoc": "0.4.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^4.1.1 || ^5.3.11",
-        "styled-system": "^5.1.5"
+        "@redocly/config": "0.20.3",
+        "@redocly/mock-server": "0.2.5",
+        "@redocly/openapi-core": "0.0.0-snapshot.1737556585",
+        "@redocly/openapi-docs": "3.6.3"
       }
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/dompurify": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.4.tgz",
-      "integrity": "sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
-    },
-    "node_modules/@redocly/portal-plugin-mock-server/node_modules/highlight-words-core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@redocly/realm": {
-      "version": "0.115.1",
-      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.115.1.tgz",
-      "integrity": "sha512-dw/znicjCuOoHP1s8Fa7cF8x/zsm12YHWDaGOZtcTtwUVg4X3/xn4A8fF241GSEXRL6M8xYV4niQRGl8ogUdUQ==",
+      "version": "0.118.2",
+      "resolved": "https://registry.npmjs.org/@redocly/realm/-/realm-0.118.2.tgz",
+      "integrity": "sha512-q0HWuj7ia36a/juMoMKnaRyUR5GctKTo8dR24zyy9j0qcgN46OA4Qsv11U23HYFFMM202G2wu8gba6Wy43wf2g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@babel/core": "7.23.5",
@@ -2015,13 +1896,13 @@
         "@opentelemetry/sdk-trace-web": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@redocly/ajv": "8.11.2",
-        "@redocly/config": "0.20.1",
-        "@redocly/graphql-docs": "0.7.14",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/openapi-docs": "3.5.19",
+        "@redocly/config": "0.20.3",
+        "@redocly/graphql-docs": "0.7.16",
+        "@redocly/openapi-core": "0.0.0-snapshot.1737556585",
+        "@redocly/openapi-docs": "3.6.3",
         "@redocly/portal-legacy-ui": "0.1.1",
-        "@redocly/portal-plugin-mock-server": "0.3.71",
-        "@redocly/theme": "0.48.1",
+        "@redocly/portal-plugin-mock-server": "0.3.76",
+        "@redocly/theme": "0.50.1",
         "@redocly/xml-crypto": "3.0.1",
         "@shikijs/transformers": "^1.22.2",
         "@tanstack/react-query": "5.62.3",
@@ -2072,6 +1953,7 @@
         "typesense": "1.8.2",
         "ulid": "^2.3.0",
         "web-vitals": "3.3.1",
+        "workerpool": "9.2.0",
         "ws": "^8.17.1",
         "yaml-ast-parser": "0.0.43"
       },
@@ -2081,147 +1963,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/config": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.1.tgz",
-      "integrity": "sha512-TYiTDtuItiv95YMsrRxyCs1HKLrDPtTvpaD3+kDKXBnFDeJuYKZ+eHXpCr6YeN4inxfVBs7DLhHsQcs9srddyQ==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/@redocly/graphql-docs/-/graphql-docs-0.7.14.tgz",
-      "integrity": "sha512-/23o5U735PyUl4iTs8WfKDzc0JfS+WJf33yMw6SN7//ufUhnW/1X46s6bzAnWUqiFFepsjTmwg1D2qEMz/HmUA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.20.0",
-        "deepmerge": "^4.2.2",
-        "marked": "^4.0.15"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "^0.48.0",
-        "graphql": "^16.9.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^5.3.11"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/graphql-docs/node_modules/@redocly/config": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.0.tgz",
-      "integrity": "sha512-JECdp+JE04YsOQXnFKu1BP1H81yhpHOJhK8hYJje5yVh5gxZyw901rjWU/KSiZYrCsuBISjZSlDXnwHwKj5VcA==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.27.1.tgz",
-      "integrity": "sha512-zQ47/A+Drk2Y75/af69MD3Oad4H9LxkUDzcm7XBkyLNDKIWQrDKDnS5476oDq77+zciymNxgMVtxxVXlnGS8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@redocly/ajv": "^8.11.2",
-        "@redocly/config": "^0.17.0",
-        "colorette": "^1.2.0",
-        "https-proxy-agent": "^7.0.4",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^5.0.1",
-        "node-fetch": "^2.6.1",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
-      },
-      "engines": {
-        "node": ">=14.19.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/@redocly/config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.17.1.tgz",
-      "integrity": "sha512-CEmvaJuG7pm2ylQg53emPmtgm4nW2nxBgwXzbVEHpGas/lGnMyN8Zlkgiz6rPw0unASg6VW3wlz27SOL5XFHYQ==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "license": "MIT"
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-core/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/openapi-docs": {
-      "version": "3.5.19",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-docs/-/openapi-docs-3.5.19.tgz",
-      "integrity": "sha512-E+tttuJHEF1adybM9VlMs42nZKv7N8alwDJe4ZkA/BbwQXE1Pk9/QhJvW7I8ZrMCcYKBhDcotVhsiFukzfuptA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@markdoc/markdoc": "0.4.0",
-        "@redocly/config": "0.20.1",
-        "@redocly/openapi-core": "1.27.1",
-        "@redocly/replay": "0.9.1",
-        "deepmerge": "^4.2.2",
-        "dompurify": "2.5.4",
-        "fast-deep-equal": "^3.1.3",
-        "jotai": "^2.4.2",
-        "json-pointer": "^0.6.2",
-        "jstoxml": "^5.0.2",
-        "openapi-sampler": "^1.6.1",
-        "path-browserify": "^1.0.1",
-        "prismjs": "1.29.0",
-        "react-router-dom": "^6.21.1",
-        "slugify": "^1.4.4",
-        "stringify-object": "^3.3.0",
-        "styled-components": "^4.1.1 || ^5.3.11",
-        "swagger2openapi": "^7.0.8",
-        "tslib": "^2.2.0",
-        "url": "~0.11.0",
-        "url-template": "^2.0.8",
-        "util": "~0.12.5"
-      },
-      "bin": {
-        "openapi-docs": "bin.js"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "@redocly/theme": ">=0.9.4",
-        "core-js": "^3.1.4",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "styled-components": "^4.1.1 || ^5.3.11"
       }
     },
     "node_modules/@redocly/realm/node_modules/@redocly/portal-legacy-ui": {
@@ -2237,90 +1978,18 @@
         "styled-system": "^5.1.5"
       }
     },
-    "node_modules/@redocly/realm/node_modules/@redocly/replay": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.9.1.tgz",
-      "integrity": "sha512-axY7rcpF92v40qjWZSziQ6ehLhg19uqChBiSMo1DY2tlUmMpVY3hj0TuDfUY21tWO+jm7CAHm6XRFsROpvw1mQ==",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.15.0",
-        "@codemirror/lang-html": "^6.4.7",
-        "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-xml": "^6.0.2",
-        "@codemirror/lint": "^6.5.0",
-        "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.25.1",
-        "@hookstate/core": "^4.0.1",
-        "@hookstate/devtools": "^4.0.1",
-        "@hookstate/localstored": "^4.0.1",
-        "@lezer/highlight": "^1.1.6",
-        "@redocly/vscode-json-languageservice": "^3.4.9",
-        "@tauri-apps/plugin-dialog": "2.0.0-beta.7",
-        "@tauri-apps/plugin-fs": "2.0.0-beta.8",
-        "@uiw/codemirror-theme-material": "^4.21.20",
-        "@uiw/react-codemirror": "^4.21.20",
-        "crypto-js": "^4.2.0",
-        "dayjs": "^1.11.7",
-        "js-yaml": "4.1.0",
-        "marked": "^4.0.15",
-        "rc-tooltip": "^6.1.3",
-        "react-resizable-panels": "^1.0.9",
-        "react-select": "5.8.1",
-        "styled-components": "^5.3.11"
-      },
-      "peerDependencies": {
-        "@redocly/theme": "0.48.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^5.3.11"
-      }
-    },
-    "node_modules/@redocly/realm/node_modules/@redocly/theme": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.48.1.tgz",
-      "integrity": "sha512-UrleXuk+/bRpF8cpqXVY4EFA+HUcVJ6+9Ii5b2FsAMNjENWSUSQeXhombF+H7LKQJHpAUa72qByUTYpcwXgqfA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@redocly/config": "0.20.1",
-        "copy-to-clipboard": "3.3.3",
-        "file-saver": "2.0.5",
-        "highlight-words-core": "1.2.2",
-        "hotkeys-js": "3.10.1",
-        "i18next": "22.4.15",
-        "jszip": "3.10.1",
-        "nprogress": "0.2.0",
-        "react-calendar": "4.2.1",
-        "react-date-picker": "10.0.3",
-        "timeago.js": "4.0.2"
-      },
-      "peerDependencies": {
-        "@markdoc/markdoc": "0.4.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.21.1",
-        "styled-components": "^4.1.1 || ^5.3.11",
-        "styled-system": "^5.1.5"
-      }
-    },
     "node_modules/@redocly/realm/node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/@redocly/realm/node_modules/dompurify": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.4.tgz",
-      "integrity": "sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
-    },
     "node_modules/@redocly/realm/node_modules/highlight-words-core": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
       "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@redocly/realm/node_modules/minimatch": {
       "version": "7.4.2",
@@ -2388,10 +2057,48 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/@redocly/replay": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@redocly/replay/-/replay-0.9.6.tgz",
+      "integrity": "sha512-fKDENkRQBy+8Xka+PF4vSRTlcbdPaPNyGGdge5sHMSBifWrRQw26/jIacE3QfYmB57UFT1gk7HyaCimumJTBCA==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.15.0",
+        "@codemirror/lang-html": "^6.4.7",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-xml": "^6.0.2",
+        "@codemirror/lint": "^6.5.0",
+        "@codemirror/state": "^6.4.1",
+        "@codemirror/view": "^6.25.1",
+        "@hookstate/core": "^4.0.1",
+        "@hookstate/devtools": "^4.0.1",
+        "@hookstate/localstored": "^4.0.1",
+        "@lezer/highlight": "^1.1.6",
+        "@redocly/vscode-json-languageservice": "^3.4.9",
+        "@tauri-apps/plugin-dialog": "2.0.0-beta.7",
+        "@tauri-apps/plugin-fs": "2.0.0-beta.8",
+        "@uiw/codemirror-theme-material": "^4.21.20",
+        "@uiw/react-codemirror": "^4.21.20",
+        "crypto-js": "^4.2.0",
+        "dayjs": "^1.11.7",
+        "js-yaml": "4.1.0",
+        "marked": "^4.0.15",
+        "rc-tooltip": "^6.1.3",
+        "react-resizable-panels": "^1.0.9",
+        "react-select": "5.8.1",
+        "styled-components": "^5.3.11"
+      },
+      "peerDependencies": {
+        "@redocly/theme": "0.50.1",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.21.1",
+        "styled-components": "^5.3.11"
+      }
+    },
     "node_modules/@redocly/theme": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.50.0.tgz",
-      "integrity": "sha512-T0Ppbx1olJen2xP5qsMfVoHWwaWccP1UYrWu2p03WfPuISU/TpRy44MIiPpqcyKKal1tMgRrk8DkVzzidDoMIA==",
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@redocly/theme/-/theme-0.50.1.tgz",
+      "integrity": "sha512-HxPVWeo+3PPMWGTseVlV3lREAH6HlMREouh10YoCVuqe+hX/MlXCiJXJJiD02KlZ+/YMKA0TogeTYLcED91+Vg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@redocly/config": "0.20.3",
@@ -2416,12 +2123,6 @@
         "styled-components": "^4.1.1 || ^5.3.11",
         "styled-system": "^5.1.5"
       }
-    },
-    "node_modules/@redocly/theme/node_modules/@redocly/config": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.3.tgz",
-      "integrity": "sha512-Nyyv1Bj7GgYwj/l46O0nkH1GTKWbO3Ixe7KFcn021aZipkZd+z8Vlu1BwkhqtVgivcKaClaExtWU/lDHkjBzag==",
-      "license": "MIT"
     },
     "node_modules/@redocly/theme/node_modules/highlight-words-core": {
       "version": "1.2.2",
@@ -3422,14 +3123,17 @@
       "license": "MIT"
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clsx": {
@@ -3752,6 +3456,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.4.tgz",
+      "integrity": "sha512-l5NNozANzaLPPe0XaAwvg3uZcHtDBnziX/HjsY1UcDj1MxTK8Dd0Kv096jyPK5HRzs/XM5IMj20dW8Fk+HnbUA==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/domutils": {
       "version": "3.2.2",
@@ -4524,9 +4234,9 @@
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -4736,9 +4446,9 @@
       }
     },
     "node_modules/jotai": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.1.tgz",
-      "integrity": "sha512-41Su098mpHIX29hF/XOpDb0SqF6EES7+HXfrhuBqVSzRkxX48hD5i8nGsEewWZNAsBWJCTTmuz8M946Ih2PfcQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.3.tgz",
+      "integrity": "sha512-B/PsewAQ0UOS5e2+TTWegUPQ3SCLPCjPY24LYUjfn2EorGlluTA2dFjVLgF1+xHLjK9Jit3y5mKHyMG3Xq/GZg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
@@ -6625,12 +6335,21 @@
       "license": "MIT"
     },
     "node_modules/slugify": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
-      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -6956,9 +6675,9 @@
       "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {
@@ -7301,6 +7020,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/workerpool": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.2.0.tgz",
+      "integrity": "sha512-PKZqBOCo6CYkVOwAxWxQaSF2Fvb5Iv2fCeTP7buyWI2GiynWr46NcXSgK/idoV6e60dgCBfgYc+Un3HMvmqP8w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7388,30 +7113,30 @@
       "license": "Apache-2.0"
     },
     "node_modules/yargs": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "realm develop"
   },
   "dependencies": {
-    "@redocly/realm": "^0.115.0",
+    "@redocly/realm": "^0.118.2",
     "@redocly/theme": "^0.50.0"
   }
 }


### PR DESCRIPTION
Based on [the changelog](https://redocly.com/docs/realm/changelog), this update brings some minor updates to Redocly including support for image lightboxes and some better error handling.