### PR TITLE
Implement Key Dates component

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -67,6 +67,39 @@ html.light .not_enabled::after {
     vertical-align: text-top;
 }
 
+/* Key Dates component */
+.key-dates {
+  background-color: #0045c6;
+  color: white;
+  width: 100%;
+  border-radius: var(--card-border-radius);
+}
+
+.key-dates h4 {
+  background-color: #006aff;
+  font-size: 3rem;
+  line-height: 3rem;
+  padding: 2rem;
+  text-align: center;
+  font-weight: normal;
+  margin: 0;
+  border-top-left-radius: var(--card-border-radius);
+  border-top-right-radius: var(--card-border-radius);
+}
+
+.key-dates ul {
+  padding: 0;
+  list-style-type: none;
+}
+
+.key-dates li {
+  padding: 1rem;
+  border-radius: 2rem;
+  background-color: #006aff;
+  margin: 1.5rem;
+}
+
+
 /* Fonts */
 @font-face {
   font-family: "TT Ripple";

--- a/components/landing.tsx
+++ b/components/landing.tsx
@@ -75,4 +75,29 @@ function ButtonToXRPL({ children }) {
   </XRPLStyledButton>
 }
 
-export { Header1, Header2, LandingContainer, LandingLayout, Jumbotron, ButtonToXRPL };
+function KeyDatesCard(props: {
+    title:string, 
+    children: React.ReactNode
+  }) {
+  return (
+  <div className="key-dates card-variant-filled">
+    <h4>{props.title}</h4>
+    <ul>
+      {props.children}
+    </ul>
+  </div>
+  )
+}
+
+function KeyDate(props: {
+    date:string,
+    children: React.ReactNode
+  }) {
+  return (
+    <li>
+      <strong>{props.date}</strong>: {props.children}
+    </li>
+  )
+}
+
+export { Header1, Header2, LandingContainer, LandingLayout, Jumbotron, ButtonToXRPL, KeyDatesCard, KeyDate };

--- a/docs/xls-80d-permissioned-domains/index.page.tsx
+++ b/docs/xls-80d-permissioned-domains/index.page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Header1, Header2, LandingContainer, LandingLayout, Jumbotron, ButtonToXRPL } from "../../components/landing";
+import { Header1, Header2, LandingContainer, LandingLayout, Jumbotron, ButtonToXRPL, KeyDatesCard, KeyDate } from "../../components/landing";
 import { Button } from "@redocly/theme";
 import { Card } from '@redocly/theme/markdoc/components/Cards/Card';
 import { Cards } from '@redocly/theme/markdoc/components/Cards/Cards';
@@ -20,12 +20,21 @@ export default function Page() {
 
       <LandingContainer>
 
-          <div style={{ maxWidth: '50%', height: 'auto' }}>
+        <Cards columns={2}>
+          <Card variant="ghost">
             <p>
               Text goes here
             </p>
-            <img src={require('./ripplex-xrpl-features-key-dates-xls80-permissioned-domains.png')} alt="Key Dates for Permissioned Domains Feature" } />
-          </div>
+          </Card>
+
+          <KeyDatesCard title="Key Dates">
+            <KeyDate date="Oct 21, 2024">XLS Spec Review Complete</KeyDate>
+            <KeyDate date="Mar 05, 2025">Feature in rippled 2.4.0</KeyDate>
+            <KeyDate date=" Mar 05, 2025">Open for voting</KeyDate>
+            <KeyDate date="TBA">Obtained ≥ 80% validators support</KeyDate>
+            <KeyDate date="TBA">Enabled on Mainnet</KeyDate>
+          </KeyDatesCard>
+        </Cards>
         
         <Cards columns={2}>
 


### PR DESCRIPTION
Use a React component instead of an image for Key Dates graphic.

Usage example:

```react
<KeyDatesCard title="Key Dates">
  <KeyDate date="Oct 21, 2024">XLS Spec Review Complete</KeyDate>
  <KeyDate date="Mar 05, 2025">Feature in rippled 2.4.0</KeyDate>
  <KeyDate date=" Mar 05, 2025">Open for voting</KeyDate>
  <KeyDate date="TBA">Obtained ≥ 80% validators support</KeyDate>
  <KeyDate date="TBA">Enabled on Mainnet</KeyDate>
</KeyDatesCard>
```

What it looks like:

![2025-03-05_162819_614637462](https://github.com/user-attachments/assets/4cfb2205-0b3e-4f82-85b4-0cba399b6a90)
