### PR TITLE
Fix aggressive word-breaking of field names in tables

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -43,6 +43,11 @@ html.light .not_enabled::after {
   filter:brightness(70%);
 }
 
+/* Don't aggressively line-break field names in tables */
+.md-table-wrapper table code {
+  word-break: normal;
+}
+
 /* ----- This configures the footer ----- */
 #gatsby-focus-wrapper > div > footer {
     line-height: 16px;


### PR DESCRIPTION
Fixes #23.

| Before | After |
|---|---|
| ![screenshot of table. field names are broken mid-word such as "accou-nt"](https://github.com/user-attachments/assets/63c28d1f-4f6c-408b-a396-3586af206736) | ![screenshot of table. field names are not line-broken](https://github.com/user-attachments/assets/b02083a1-9cf0-4c06-8bf0-56e6d713bd6b) |
