### PR TITLE
Fix metadata blurbs

### DIFF
--- a/docs/xls-56d-batch-transactions/concepts/batch-transactions.md
+++ b/docs/xls-56d-batch-transactions/concepts/batch-transactions.md
@@ -1,5 +1,6 @@
 ---
-blurb: Batch allows up to 8 transactions to be submitted as a single unit.
+seo:
+  description: Batch allows up to 8 transactions to be submitted as a single unit.
 labels:
   - Batch
   - Transactions

--- a/docs/xls-56d-batch-transactions/index.md
+++ b/docs/xls-56d-batch-transactions/index.md
@@ -1,5 +1,6 @@
 ---
-blurb: Batch allows up to 8 transactions to be submitted as a single unit.
+seo:
+  description: Batch allows up to 8 transactions to be submitted as a single unit.
 labels:
   - Batch
   - Transactions

--- a/docs/xls-56d-batch-transactions/reference/batch.md
+++ b/docs/xls-56d-batch-transactions/reference/batch.md
@@ -1,5 +1,6 @@
 ---
-blurb: Create and submit a batch of up to 8 transactions.
+seo:
+  description: Create and submit a batch of up to 8 transactions.
 labels:
  - Batch, Atomic Batch
 ---

--- a/docs/xls-65d-single-asset-vault/concepts/pseudo-account.md
+++ b/docs/xls-65d-single-asset-vault/concepts/pseudo-account.md
@@ -1,5 +1,6 @@
 ---
-blurb: A pseudo-account is a special type of XRPL account that holds assets on behalf of an on-chain protocol.
+seo:
+  description: A pseudo-account is a special type of XRPL account that holds assets on behalf of an on-chain protocol.
 labels:
   - Single Asset Vault 
 status: not_enabled

--- a/docs/xls-65d-single-asset-vault/concepts/single-asset-vault.md
+++ b/docs/xls-65d-single-asset-vault/concepts/single-asset-vault.md
@@ -1,5 +1,6 @@
 ---
-blurb: A single asset vault aggregates assets from multiple depositors and makes them available to other on-chain protocols.
+seo:
+  description: A single asset vault aggregates assets from multiple depositors and makes them available to other on-chain protocols.
 labels:
   - Single Asset Vault 
 status: not_enabled


### PR DESCRIPTION
The `blurb` frontmatter field was used by Dactyl but Redocly needs the `description:` sub-field of `seo:` instead.

This is necessary to fix #25 although I don't know if we might also need to take other steps to get Redocly to return unique metadata per page.