### PR TITLE
Fix deep freeze docs link

### DIFF
--- a/docs/xls-77d-deep-freeze/index.page.tsx
+++ b/docs/xls-77d-deep-freeze/index.page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
 
           <Card
             title="Documentation"
-            to="https://xrpl.org/docs/concepts/tokens/decentralized-exchange/permissioned-domains"
+            to="https://xrpl.org/docs/concepts/tokens/fungible-tokens/deep-freeze"
           >
             <p>
               Explore key concepts, find detailed references, and follow


### PR DESCRIPTION
Looks like a copy-paste error had it linking to Permissioned Domains docs instead.