### PR TITLE
Fix token escrow landing page

### DIFF
--- a/docs/xls-85-token-escrow/index.page.tsx
+++ b/docs/xls-85-token-escrow/index.page.tsx
@@ -12,9 +12,9 @@ import { Cards } from "@redocly/theme/markdoc/components/Cards/Cards";
 
 export const frontmatter = {
   seo: {
-    title: "XLS-34 Token Enabled Escrows and Payment Channels",
+    title: "XLS-85 Token Escrow",
     description:
-      "Learn how trustline balances are enabled for escrows and payment channels.",
+      "Learn how trustline balances are enabled for escrows.",
   },
 };
 
@@ -31,19 +31,19 @@ export default function Page() {
     <LandingLayout>
       <LandingContainer>
         <FeatureHeader 
-          title="XLS-0034 Token Escrow and Payment Channels"
-          subtitle="Token escrow and payment channels support both XRP and tokenized assets."
+          title="XLS-0085 Token Escrow"
+          subtitle="Token escrow supports both XRP and tokenized assets."
         />
 
         <FeatureContent 
-          description="Token Escrow and Payment Channels support both XRP and tokenized assets."
+          description="Token escrow supports both XRP and tokenized assets."
           keyDates={keyDates}
         />
 
         <Cards columns={3}>
           <Card
             title="XLS Spec"
-            to="https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0034d-paychan-escrow-for-tokens/"
+            to="https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0085d-token-escrow"
           >
             <p>
               Technical spec for the feature outlining requirements, design,
@@ -56,7 +56,7 @@ export default function Page() {
 
           <Card
             title="Documentation"
-            to="https://xrpl.org/docs/concepts/tokens/fungible-tokens"
+            to="https://xrpl.org/docs/concepts/payment-types/escrow"
           >
             <p>
               Explore key concepts, find detailed references, and follow

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -65,8 +65,8 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Token-Enabled Escrows and Payment Channels" to="docs/xls-34-token-escrow-and-payment-channels">
-            <p>The proposed amendment would introduce changes to the ledger objects, transactions, and rpc methods to enable Escrows and Payment Channels to use Trustline balances.</p>
+          <Card title="Token Escrow" to="docs/xls-85-token-escrow">
+            <p>Extends the existing Escrow functionality to support escrowing issued tokens or Multi-purpose tokens (MPTs).</p>
             <Button size="large" variant="primary">
               Learn more
             </Button>

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,50 +1,50 @@
 # token escrow and payment channel docs
-/docs/xls-34d-token-escrow-and-payment-channels:
-  to: /docs/xls-34-token-escrow-and-payment-channels
+/docs/xls-34-token-escrow-and-payment-channels:
+  to: /docs/xls-85-token-escrow
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/token-escrow-payment-channels:
+/docs/xls-34-token-escrow-and-payment-channels/token-escrow-payment-channels:
   to: https://xrpl.org/docs/concepts/tokens/fungible-tokens
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/concepts/escrow:
+/docs/xls-34-token-escrow-and-payment-channels/concepts/escrow:
   to: https://xrpl.org/docs/concepts/payment-types/escrow
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/concepts/payment-channels:
+/docs/xls-34-token-escrow-and-payment-channels/concepts/payment-channels:
   to: https://xrpl.org/docs/concepts/payment-types/payment-channels
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/concepts/ripplestate:
+/docs/xls-34-token-escrow-and-payment-channels/concepts/ripplestate:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/account_channels:
+/docs/xls-34-token-escrow-and-payment-channels/reference/account_channels:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/account_lines:
+/docs/xls-34-token-escrow-and-payment-channels/reference/account_lines:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/account_objects:
+/docs/xls-34-token-escrow-and-payment-channels/reference/account_objects:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/channel_authorize:
+/docs/xls-34-token-escrow-and-payment-channels/reference/channel_authorize:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_authorize
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/channel_verify:
+/docs/xls-34-token-escrow-and-payment-channels/reference/channel_verify:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/escrow:
+/docs/xls-34-token-escrow-and-payment-channels/reference/escrow:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/escrow
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/escrowcreate:
+/docs/xls-34-token-escrow-and-payment-channels/reference/escrowcreate:
   to: https://xrpl.org/docs/references/protocol/transactions/types/escrowcreate
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/paychannel:
+/docs/xls-34-token-escrow-and-payment-channels/reference/paychannel:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelclaim:
+/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelclaim:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelclaim
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelcreate:
+/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelcreate:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelcreate
   type: 301
-/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelfund:
+/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelfund:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelfund
   type: 301
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,50 +1,50 @@
 # token escrow and payment channel docs
-/docs/xls-34-token-escrow-and-payment-channels:
+/docs/xls-34d-token-escrow-and-payment-channels:
   to: /docs/xls-85-token-escrow
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/token-escrow-payment-channels:
+/docs/xls-34d-token-escrow-and-payment-channels/token-escrow-payment-channels:
   to: https://xrpl.org/docs/concepts/tokens/fungible-tokens
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/concepts/escrow:
+/docs/xls-34d-token-escrow-and-payment-channels/concepts/escrow:
   to: https://xrpl.org/docs/concepts/payment-types/escrow
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/concepts/payment-channels:
+/docs/xls-34d-token-escrow-and-payment-channels/concepts/payment-channels:
   to: https://xrpl.org/docs/concepts/payment-types/payment-channels
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/concepts/ripplestate:
+/docs/xls-34d-token-escrow-and-payment-channels/concepts/ripplestate:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/account_channels:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/account_channels:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_channels
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/account_lines:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/account_lines:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_lines
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/account_objects:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/account_objects:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/channel_authorize:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/channel_authorize:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_authorize
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/channel_verify:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/channel_verify:
   to: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/payment-channel-methods/channel_verify
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/escrow:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/escrow:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/escrow
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/escrowcreate:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/escrowcreate:
   to: https://xrpl.org/docs/references/protocol/transactions/types/escrowcreate
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/paychannel:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/paychannel:
   to: https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/paychannel
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelclaim:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelclaim:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelclaim
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelcreate:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelcreate:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelcreate
   type: 301
-/docs/xls-34-token-escrow-and-payment-channels/reference/paymentchannelfund:
+/docs/xls-34d-token-escrow-and-payment-channels/reference/paymentchannelfund:
   to: https://xrpl.org/docs/references/protocol/transactions/types/paymentchannelfund
   type: 301
 

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -4,7 +4,7 @@
   expanded: true
   items:
     - page: docs/xls-33-multi-purpose-tokens/index.page.tsx
-    - page: docs/xls-34-token-escrow-and-payment-channels/index.page.tsx
+    - page: docs/xls-85-token-escrow/index.page.tsx
     - page: docs/xls-56-batch-transactions/index.page.tsx
     - group:
       page: docs/xls-65d-single-asset-vault/index.page.tsx


### PR DESCRIPTION
Updating this based on request from Shashwat

> Can someone on the docs team help me get the Token Escrow page updated on Ripple Open Source?  
> 1. It should be referencing this spec: [https://github.com/XRPLF/XRPL-Standards/discussions/248](https://github.com/XRPLF/XRPL-Standards/discussions/248) instead of [https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0034d-paychan-escrow-for-tokens/](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0034d-paychan-escrow-for-tokens/)
> 2. In line with that, the title should be  "Token Escrow" and should not include Paychans
> 3. Documentation link right now links to the Fungible Tokens page, it should point to content focused on Token Escrows.