### PR TITLE
Remove broken GTM noscript causing syntax error

### DIFF
--- a/redocly.yaml
+++ b/redocly.yaml
@@ -8,11 +8,8 @@ seo:
       content: "bLwyBi1imklcIuQxZ7JeI_kRF5Mg7yfr6arpEQV2nsE"
 scripts:
   head:
-    # GTM script for the head
+    # Google Tag Manager script for the head
     - src: ./static/js/gtm-head.js
-  body:
-    # GTM noscript for immediately after the opening body tag
-    - src: ./static/js/gtm-body.js
 redirects:
   $ref: redirects.yaml
 navbar:

--- a/static/js/gtm-body.js
+++ b/static/js/gtm-body.js
@@ -1,2 +1,0 @@
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W3ND7TWZ"
-        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
The GTM-body "script" is not a script, so attempting to load it like a script is causing the site to report a syntax error:

```txt
Uncaught SyntaxError: expected expression, got '<'
```

The simple fix is to remove this configuration & file. The GTM should be covered by the other cases anyway. At most, users with scripts disabled won't have analytics, which is probably fine because the site probably won't work at all for those users anyway.