### PR TITLE
chore: remove unused ButtonToXRPL import

### DIFF
--- a/index.page.tsx
+++ b/index.page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Header1, Header2, LandingContainer, LandingLayout, Jumbotron, ButtonToXRPL } from "./components/landing";
+import { Header1, Header2, LandingContainer, LandingLayout, Jumbotron } from "./components/landing";
 import { Button } from "@redocly/theme";
 import { Card } from '@redocly/theme/markdoc/components/Cards/Card';
 import { Cards } from '@redocly/theme/markdoc/components/Cards/Cards';


### PR DESCRIPTION
ButtonToXRPL is imported but not used on this page. Removes unused import to keep the code clean.
