### PR TITLE
XLS-68 - Documentation for Sponsored Fees and Reserves

### DIFF
--- a/docs/_snippets/common-links.md
+++ b/docs/_snippets/common-links.md
@@ -29,6 +29,12 @@
 [seconds since the Ripple Epoch]: https://xrpl.org/docs/references/protocol/data-types/basic-data-types#specifying-time
 [SHA-512Half]: https://xrpl.org/docs/references/protocol/data-types/basic-data-types#hashes
 [Specifying Ledgers]: https://xrpl.org/docs/references/protocol/data-types/basic-data-types/#specifying-ledgers
+[Sponsor amendment]: https://xls.xrpl.org/xls/XLS-0068-sponsored-fees-and-reserves.html
+[Sponsorship ledger entry]: /docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/sponsorship.md
+[SponsorshipSet]: /docs/xls-68-sponsored-fees-and-reserves/transactions/sponsorshipset.md
+[SponsorshipSet transaction]: /docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshipset.md
+[SponsorshipTransfer]: /docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
+[SponsorshipTransfer transaction]: /docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
 [standard format]: https://xrpl.org/docs/references/http-websocket-apis/api-conventions/response-formatting/
 [transaction result codes]: https://xrpl.org/docs/references/protocol/transactions/transaction-results
 [universal error types]: https://xrpl.org/docs/references/http-websocket-apis/api-conventions/error-formatting#universal-errors

--- a/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
@@ -1,0 +1,126 @@
+---
+seo:
+    description: Sponsors can pay transaction fees and reserve requirements on behalf of other accounts on the XRP Ledger.
+labels:
+  - Fees
+  - Accounts
+  - Sponsorship
+status: not_enabled
+---
+# Sponsored Fees and Reserves
+
+The Sponsored Fees and Reserves feature allows an account to pay transaction fees and reserve requirements on behalf of another account. The account that pays is called the _Sponsor_, and the account that benefits is called the _Sponsee_. Sponsees maintain full control over their keys and accounts while sponsors handle transaction submission and cover the associated costs.
+
+Without sponsorship, accounts must self-fund both transaction fees and reserves before they can transact on the XRP Ledger. Sponsorship provides a mechanism for entities with established XRP balances to subsidize these costs while maintaining strong on-chain accountability.
+
+Sponsorship enables several important use cases, including:
+
+- **Token distribution**: Issuers can distribute tokens without requiring recipients to hold XRP first.
+- **NFT minting**: Creators can enable users to mint NFTs without upfront XRP costs.
+- **Enterprise onboarding**: Businesses can onboard customers seamlessly without blockchain friction.
+
+{% admonition type="success" name="Tip" %}
+Similar features on other chains are often called "sponsored transactions", "meta-transactions", or "relays".
+{% /admonition %}
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## How Sponsorship Works
+
+XRP Ledger accounts can include signatures from sponsors in their transactions, allowing sponsors to pay the transaction cost and the reserve for any accounts or objects created in the transaction. Alternatively, sponsors can pre-fund fees or reserves if they do not want to co-sign every sponsored transaction.
+
+For example, consider Spencer (sponsor) who wants to cover costs for Alice (sponsee):
+
+- **Co-signing**: Alice constructs her transaction and includes Spencer's account and sponsorship type. Spencer signs the transaction, Alice adds his signature, then signs and submits it herself. This gives Spencer fine-grained control over every sponsored transaction.
+
+- **Pre-funding**: Spencer submits a [SponsorshipSet transaction][] to allocate funds for Alice. From then on, Alice can submit transactions that reference Spencer as her sponsor without needing his signature each time. Spencer's involvement ends after the initial setup.
+
+### Enabling Sponsorship and Covering Costs
+
+For a transaction to be sponsored, at least one of the following flags must be enabled:
+
+- `spfSponsorFee`: This flag indicates that the sponsor pays the transaction fee.
+- `spfSponsorReserve`: This flag indicates that the sponsor covers the reserve for accounts or objects created in a transaction. No XRP is transferred to the sponsee; the sponsor's XRP stays in their own account, and the ledger simply tracks which account is responsible for holding the reserve.
+
+If a transaction has **both** flags enabled, the sponsor pays for the fee and any reserves for newly created accounts or objects. Additionally, a single transaction cannot have different sponsors for the fee and the reserve; both must come from the same sponsor.
+
+{% admonition type="warning" name="Note" %}
+All transactions, other than pseudo-transactions, can use the `spfSponsorFee` flag since they all have a fee.
+
+However, some transactions do not support the `spfSponsorReserve` flag:
+
+- **Batch** transactions do not create objects, so `spfSponsorReserve` has no effect. To sponsor reserves for transactions within a batch, use `spfSponsorReserve` on the _inner_ transactions instead.
+
+- **Pseudo-transactions** do not support the `spfSponsorReserve` flag, since fees and reserves for these transactions are covered by the network, not by any one account.
+
+- Transactions that do not create any _new_ objects or accounts, such as AccountSet, have no effect when using `spfSponsorReserve`.
+{% /admonition %}
+
+### Reserve Calculation
+
+Sponsorship modifies the reserve formula, shifting the burden from the sponsee to the sponsor.
+
+The standard reserve calculation is:
+
+```txt
+acctReserve + objReserve × acct.OwnerCount
+```
+
+With sponsorship, the calculation becomes:
+
+```txt
+(acct.Sponsor ? 0 : acctReserve) +
+objReserve × (acct.OwnerCount + acct.SponsoringOwnerCount - acct.SponsoredOwnerCount) +
+acctReserve × acct.SponsoringAccountCount
+```
+
+- If the account has a `Sponsor` field, meaning its account reserve is sponsored, the base account reserve requirement is 0 for that account, and the sponsor covers it instead.
+- `SponsoringOwnerCount` tracks objects this account sponsors.
+- `SponsoredOwnerCount` tracks objects owned by this account that are sponsored by others.
+- `SponsoringAccountCount` tracks accounts this account sponsors.
+
+### Security Considerations
+
+Sponsorship includes safeguards to protect both parties from misuse:
+
+- **Co-signed flow**: Both parties must consent to each transaction by providing their signatures. The sponsor signs the entire transaction, including the sponsee's `Account` and `Sequence` fields, which prevents signature replay attacks. The sponsor also approves the `Fee` value and any fields that affect reserve requirements, such as `Destination` and `TicketCount`.
+
+- **Pre-funded flow**: The sponsor consents once when submitting a `SponsorshipSet` transaction. The sponsee cannot modify the terms or exceed the deposited amount. The sponsor can limit usage with `MaxFee` and `ReserveCount`, or require their signature for specific transactions using the `lsfSponsorshipRequireSignForFee` or `lsfSponsorshipRequireSignForReserve` flags.
+
+The sponsee cannot unilaterally change the sponsorship type, and the sponsor's funds cannot be used beyond the agreed terms. Only the sponsee can transfer a sponsorship to a new sponsor, and the new sponsor must co-sign the transaction to consent. Either party can exit a relationship at any time by submitting a [SponsorshipTransfer transaction][].
+
+## Managing Sponsorships
+
+Over time, sponsors may want to recoup their reserves, and sponsees may want to change sponsors or take on the reserve burden themselves. The [SponsorshipTransfer transaction][] supports three operations:
+
+- **End sponsorship**: Either the sponsor or sponsee can end a sponsorship at any time. The reserve burden returns to the object owner.
+- **Create sponsorship**: Only the sponsee can create a new sponsorship. The new sponsor provides their signature via the standard signing flow.
+- **Reassign sponsorship**: Only the sponsee can transfer an existing sponsorship to a new sponsor. The old sponsor is not directly involved.
+
+{% admonition type="warning" name="Warning" %}
+When transferring the reserve burden back to a sponsee, the sponsee must have enough XRP to cover the reserve. If they do not, and the sponsor needs to exit the relationship quickly, the sponsor can pay the sponsee the XRP needed. However, the sponsor will **not** get their reserve back.
+
+These steps can be executed atomically via a [Batch transaction](https://xrpl.org/docs/concepts/transactions/batch-transactions), to ensure that the sponsee cannot use the funds for something else before the transfer is validated.
+{% /admonition %}
+
+### Recouping Object Reserves
+
+A sponsor who wants to recoup the reserve held for a sponsee's object, such as an NFT or trust line, can use the [SponsorshipTransfer transaction][] to transfer the reserve burden back to the sponsee or to a different sponsor.
+
+### Recouping Account Reserves
+
+A sponsor who wants to recoup the reserve held for a sponsee's account has two options:
+
+- **If the sponsee is done using their account**: The sponsee can submit an [AccountDelete transaction](https://xrpl.org/docs/references/protocol/transactions/types/accountdelete). The destination, where leftover XRP goes, must be the sponsor's account. This ensures the sponsor gets their reserve back.
+
+  {% admonition type="info" name="Note" %}
+  Any sponsored objects owned by the sponsee are [deletion blockers](https://xrpl.org/docs/concepts/accounts/deleting-accounts/#requirements) and must be removed before the account can be deleted.
+  {% /admonition %}
+
+- **If the sponsee wants to keep their account**: Use the [SponsorshipTransfer transaction][] to remove the sponsorship or transfer it to a different sponsor.
+
+### Deleting a Sponsor's Account
+
+A sponsor's account cannot be deleted if it is sponsoring any existing accounts or objects. To unblock deletion, the sponsor can ask the sponsee to delete those objects, or use a [SponsorshipTransfer transaction][] to transfer the reserve burden back to the sponsee or to another sponsor. Sponsors cannot delete sponsored objects directly.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
@@ -93,9 +93,9 @@ The sponsee cannot unilaterally change the sponsorship type, and the sponsor's f
 
 Over time, sponsors may want to recoup their reserves, and sponsees may want to change sponsors or take on the reserve burden themselves. The [SponsorshipTransfer transaction][] supports three operations:
 
-- **End sponsorship**: Either the sponsor or sponsee can end a sponsorship at any time. The reserve burden returns to the object owner.
 - **Create sponsorship**: Only the sponsee can create a new sponsorship. The new sponsor provides their signature via the standard signing flow.
 - **Reassign sponsorship**: Only the sponsee can transfer an existing sponsorship to a new sponsor. The old sponsor is not directly involved.
+- **End sponsorship**: Either the sponsor or sponsee can end a sponsorship at any time. The reserve burden returns to the object owner.
 
 {% admonition type="warning" name="Warning" %}
 When transferring the reserve burden back to a sponsee, the sponsee must have enough XRP to cover the reserve. If they do not, and the sponsor needs to exit the relationship quickly, the sponsor can pay the sponsee the XRP needed. However, the sponsor will **not** get their reserve back.

--- a/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
@@ -11,6 +11,10 @@ status: not_enabled
 
 The Sponsored Fees and Reserves feature allows an account to pay transaction fees and reserve requirements on behalf of another account. The account that pays is called the _Sponsor_, and the account that benefits is called the _Sponsee_. Sponsees maintain full control over their keys and accounts while sponsors handle transaction submission and cover the associated costs.
 
+{% admonition type="info" name="Note" %}
+Sponsorship does not transfer XRP to the sponsee's wallet. The sponsor's XRP stays in the sponsor's account, and the ledger tracks which account is responsible for holding the reserve. This is not an "onramp" for the sponsee; it is a mechanism for the sponsor to cover costs on the sponsee's behalf.
+{% /admonition %}
+
 Without sponsorship, accounts must self-fund both transaction fees and reserves before they can transact on the XRP Ledger. Sponsorship provides a mechanism for entities with established XRP balances to subsidize these costs while maintaining strong on-chain accountability.
 
 Sponsorship enables several important use cases, including:
@@ -33,7 +37,7 @@ For example, consider Spencer (sponsor) who wants to cover costs for Alice (spon
 
 - **Co-signing**: Alice constructs her transaction and includes Spencer's account and sponsorship type. Spencer signs the transaction, Alice adds his signature, then signs and submits it herself. This gives Spencer fine-grained control over every sponsored transaction.
 
-- **Pre-funding**: Spencer submits a [SponsorshipSet transaction][] to allocate funds for Alice. From then on, Alice can submit transactions that reference Spencer as her sponsor without needing his signature each time. Spencer's involvement ends after the initial setup.
+- **Pre-funding**: Spencer submits a [SponsorshipSet transaction][] to allocate funds for Alice. This can cover both transaction fees and reserves for new objects, such as trust lines, escrows, or NFTs. From then on, Alice can submit transactions that reference Spencer as her sponsor without needing his signature each time. Spencer's involvement ends after the initial setup.
 
 ### Enabling Sponsorship and Covering Costs
 

--- a/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
@@ -31,7 +31,8 @@ _(Requires the [Sponsor amendment][] {% not-enabled /%})_
 
 ## How Sponsorship Works
 
-XRP Ledger accounts can include signatures from sponsors in their transactions, allowing sponsors to pay the transaction cost and the reserve for any accounts or objects created in the transaction. Alternatively, sponsors can pre-fund fees or reserves if they do not want to co-sign every sponsored transaction.
+XRP Ledger accounts can be sponsored in one of two ways: **co-signing** or **pre-funding**.
+Co-signing requires sponsors to sign each transaction, allowing them to pay the transaction cost and the reserve for any accounts or objects created in the transaction. Pre-funding lets sponsors allocate funds in advance to cover fees and reserves so they do not need to sign every sponsored transaction.
 
 For example, consider Spencer (sponsor) who wants to cover costs for Alice (sponsee):
 
@@ -49,7 +50,7 @@ For a transaction to be sponsored, at least one of the following flags must be e
 If a transaction has **both** flags enabled, the sponsor pays for the fee and any reserves for newly created accounts or objects. Additionally, a single transaction cannot have different sponsors for the fee and the reserve; both must come from the same sponsor.
 
 {% admonition type="warning" name="Note" %}
-All transactions, other than pseudo-transactions, can use the `spfSponsorFee` flag since they all have a fee.
+All transactions, other than [pseudo-transactions](https://xrpl.org/docs/references/protocol/transactions/pseudo-transaction-types), can use the `spfSponsorFee` flag since they all have a fee.
 
 However, some transactions do not support the `spfSponsorReserve` flag:
 

--- a/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
+++ b/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import {
+  LandingContainer,
+  LandingLayout,
+  FeatureHeader,
+  FeatureContent
+} from "../../components/landing";
+import { AmendmentTracker } from "../../components/AmendmentTracker";
+import { Button } from "@redocly/theme";
+import { Card } from '@redocly/theme/markdoc/components/Cards/Card';
+import { Cards } from '@redocly/theme/markdoc/components/Cards/Cards';
+
+export const frontmatter = {
+  seo: {
+    title: 'XLS-68 Sponsored Fees and Reserves',
+    description: "Enable sponsors to pay transaction fees and reserves on behalf of other accounts, reducing barriers to entry on the XRP Ledger."
+  }
+};
+
+export default function Page() {
+  const KEY_DATE_EVENTS = [
+    "XLS Spec Live",
+    "Available to Test on Devnet",
+    "Open for Voting on Mainnet",
+    "Vote Consensus"
+  ];
+
+  const [keyDates, setKeyDates] = React.useState(
+    KEY_DATE_EVENTS.map(event => ({ date: "🔄 Loading...", event }))
+  );
+
+  const handleKeyDatesUpdate = React.useCallback((newKeyDates: any[]) => {
+    setKeyDates(newKeyDates);
+  }, []);
+
+  return (
+    <LandingLayout>
+      <LandingContainer>
+        <FeatureHeader
+          title="XLS-68 Sponsored Fees and Reserves"
+          subtitle="Sponsors pay transaction fees and reserves on behalf of other accounts (sponsees)."
+        />
+
+        <FeatureContent
+          description="Sponsored Fees and Reserves removes onboarding friction by allowing companies, token issuers, and other entities to subsidize transaction costs and reserve requirements for end users. Sponsors can co-sign transactions or pre-fund sponsorships, covering fees and reserves, while sponsees retain full control of their accounts and keys."
+          keyDates={keyDates}
+        />
+
+        <AmendmentTracker
+          amendmentId="BE1F90581635DBCEBFC4678C4B54FEDDC1A17B50FD02CFE765A4132A342126AC"
+          xlsSpecDate="2026-01-30"
+          onKeyDatesUpdate={handleKeyDatesUpdate}
+        />
+
+        <Cards columns={2}>
+          <Card
+            title="XLS Spec"
+            to="https://xls.xrpl.org/xls/XLS-0068-sponsored-fees-and-reserves.html"
+          >
+            <p>
+              Technical spec for the feature outlining requirements, design,
+              and implementation details.
+            </p>
+            <Button size="large" variant="primary">
+              Read the XLS Spec
+            </Button>
+          </Card>
+
+          <Card
+            title="Documentation"
+            to="docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves"
+          >
+            <p>
+              Explore key concepts, find detailed references, and follow
+              step-by-step tutorials.
+            </p>
+            <Button size="large" variant="primary">
+              Read the Docs
+            </Button>
+          </Card>
+        </Cards>
+      </LandingContainer>
+    </LandingLayout>
+  );
+}

--- a/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
+++ b/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
@@ -78,6 +78,18 @@ export default function Page() {
               Read the Docs
             </Button>
           </Card>
+
+          <Card
+            title="Security Audit"
+            to="https://github.com/fyeo-io/public-audit-reports/blob/main/Code%20Audit%20Reports/2026/Ripple/Ripple%20-%20Security%20Code%20Review%20of%20XRPL%20Sponsored%20Fees%20and%20Reserves%20v1.0.pdf"
+          >
+            <p>
+              The security audit performed by third-party security experts, including a link to the full, detailed security audit report.
+            </p>
+            <Button size="large" variant="primary">
+              Read the Security Audit Report
+            </Button>
+          </Card>
         </Cards>
       </LandingContainer>
     </LandingLayout>

--- a/docs/xls-68-sponsored-fees-and-reserves/references/apis/account_sponsoring.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/apis/account_sponsoring.md
@@ -1,0 +1,265 @@
+---
+seo:
+    description: Retrieve all objects an account is currently sponsoring using the Clio server.
+labels:
+  - Fees
+  - Accounts
+  - Sponsorship
+status: not_enable
+---
+# account_sponsoring
+
+<!-- TODO: Update when this is implemented in Clio -->
+[[Source]](https://github.com/XRPLF/clio "Source")
+
+The `account_sponsoring` method returns all objects an account is currently sponsoring, where the queried account is the `Sponsor`, or for trust lines, the `HighSponsor` or `LowSponsor`. It has a very similar API to [account_objects](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects).
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+{% admonition type="info" name="Note" %}
+This API method is available in **Clio only**, not in `rippled`. This is because this API would require an additional database to track sponsorship relationships, which would be too expensive to maintain in `rippled`.
+{% /admonition %}
+
+## Request Format
+
+An example of a request format:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+  "id": 1,
+  "command": "account_sponsoring",
+  "account": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+  "ledger_index": "validated",
+  "limit": 10
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+  "method": "account_sponsoring",
+  "params": [
+    {
+      "account": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+      "ledger_index": "validated",
+      "limit": 10
+    }
+  ]
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```sh
+rippled account_sponsoring rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw ledger_index=validated limit=10
+```
+{% /tab %}
+
+{% /tabs %}
+
+The request includes the following parameters:
+
+| Field                    | Type                       | Required? | Description |
+|:-------------------------|:---------------------------|:----------|:------------|
+| `account`                | String                     | Yes       | The sponsor account to query. |
+| `deletion_blockers_only` | Boolean                    | No        | If `true`, the response only includes objects that would block this account from being deleted. The default is `false`. |
+| `ledger_hash`            | String                     | No        | A 20-byte hex string for the ledger version to use. See [Specifying Ledgers][]. |
+| `ledger_index`           | String or Unsigned Integer | No        | The [ledger index][] of the ledger to use, or a shortcut string to choose a ledger automatically. See [Specifying Ledgers][]. |
+| `limit`                  | Number                     | No        | The maximum number of objects to include in the results. |
+| `marker`                 | Marker                     | No        | Value from a previous paginated response. Resume retrieving data where that response left off. |
+| `type`                   | String                     | No        | Filter results by a ledger entry type. Some examples are `offer` and `escrow`. |
+
+## Response Format
+
+An example of a successful response:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+  "id": 1,
+  "result": {
+    "account": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+    "sponsored_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rSponsee1ABC123XYZ456DEF789GHI",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879",
+        "PreviousTxnLgrSeq": 14090896,
+        "index": "9ED4406351B7A511A012A9B5E7FE4059FA2F7650621379C0013492C315E25B97"
+      },
+      {
+        "Account": "rSponsee2XYZ789ABC123DEF456GHI",
+        "Balance": "1000000",
+        "Flags": 0,
+        "LedgerEntryType": "AccountRoot",
+        "OwnerCount": 3,
+        "PreviousTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+        "PreviousTxnLgrSeq": 14091574,
+        "Sequence": 1,
+        "Sponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+      }
+    ],
+    "ledger_hash": "4C99E5F63C0D0B1C2283D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3",
+    "ledger_index": 14091625,
+    "validated": true
+  },
+  "status": "success",
+  "type": "response"
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+  "result": {
+    "account": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+    "sponsored_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rSponsee1ABC123XYZ456DEF789GHI",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879",
+        "PreviousTxnLgrSeq": 14090896,
+        "index": "9ED4406351B7A511A012A9B5E7FE4059FA2F7650621379C0013492C315E25B97"
+      },
+      {
+        "Account": "rSponsee2XYZ789ABC123DEF456GHI",
+        "Balance": "1000000",
+        "Flags": 0,
+        "LedgerEntryType": "AccountRoot",
+        "OwnerCount": 3,
+        "PreviousTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+        "PreviousTxnLgrSeq": 14091574,
+        "Sequence": 1,
+        "Sponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+      }
+    ],
+    "ledger_hash": "4C99E5F63C0D0B1C2283D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3",
+    "ledger_index": 14091625,
+    "validated": true,
+    "status": "success"
+  }
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```json
+{
+  "result": {
+    "account": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+    "sponsored_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rSponsee1ABC123XYZ456DEF789GHI",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "E3FE6EA3D48F0C2B639448020EA4F03D4F4F8FFDB243A852A0F59177921B4879",
+        "PreviousTxnLgrSeq": 14090896,
+        "index": "9ED4406351B7A511A012A9B5E7FE4059FA2F7650621379C0013492C315E25B97"
+      },
+      {
+        "Account": "rSponsee2XYZ789ABC123DEF456GHI",
+        "Balance": "1000000",
+        "Flags": 0,
+        "LedgerEntryType": "AccountRoot",
+        "OwnerCount": 3,
+        "PreviousTxnID": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+        "PreviousTxnLgrSeq": 14091574,
+        "Sequence": 1,
+        "Sponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "index": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8"
+      }
+    ],
+    "ledger_hash": "4C99E5F63C0D0B1C2283D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3D3",
+    "ledger_index": 14091625,
+    "validated": true,
+    "status": "success"
+  }
+}
+```
+{% /tab %}
+
+{% /tabs %}
+
+The response follows the [standard format][], with a successful result containing the following fields:
+
+| Field                  | Type    | Description |
+|:-----------------------|:--------|:------------|
+| `account`              | String  | The account this request corresponds to. |
+| `sponsored_objects`    | Array   | Array of ledger entries that this account is sponsoring. Includes objects owned by this account and objects owned by others, such as escrows where this account is the destination. Each member is a ledger entry in its raw ledger format. This may contain fewer entries than the maximum specified in the `limit` field. |
+| `ledger_hash`          | String  | _(May be omitted)_ The identifying hash of the ledger that was used to generate this response. |
+| `ledger_index`         | Number  | _(May be omitted)_ The ledger index of the ledger that was used to generate this response. |
+| `ledger_current_index` | Number  | _(May be omitted)_ The ledger index of the current in-progress ledger, which was used when retrieving this data. |
+| `limit`                | Number  | _(May be omitted)_ The limit that was used in this request, if any. |
+| `marker`               | Marker  | _(May be omitted)_ Server-defined value indicating the response is paginated. Pass this to the next call to resume where this call left off. |
+| `validated`            | Boolean | _(May be omitted)_ If `true`, the information in this response comes from a validated ledger version. Otherwise, the information is subject to change. |
+
+## Possible Errors
+
+- Any of the [universal error types][].
+- `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
+- `actNotFound` - The address specified in the `account` field of the request does not correspond to an account in the ledger.
+- `lgrNotFound` - The ledger specified by the `ledger_hash` or `ledger_index` does not exist, or it does exist but the server does not have it.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/apis/updated-apis.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/apis/updated-apis.md
@@ -1,0 +1,191 @@
+# Updated APIs
+
+This page describes updates to existing RPC methods introduced by XLS-68: Sponsored Fees and Reserves.
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## account_objects
+
+The [account_objects method](https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_objects) adds a new optional filter parameter to query sponsored objects.
+
+| Field       | Type    | Required? | Description |
+|:------------|:--------|:----------|:------------|
+| `sponsored` | Boolean | No        | If `true`, returns only sponsored objects (objects with a `Sponsor`, `HighSponsor`, or `LowSponsor` field). If `false`, returns only non-sponsored objects. If omitted, returns all objects (existing behavior). |
+
+### Request Format
+
+An example of the request format:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+  "id": 1,
+  "command": "account_objects",
+  "account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "sponsored": true,
+  "ledger_index": "validated",
+  "type": "state"
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+  "method": "account_objects",
+  "params": [
+    {
+      "account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+      "sponsored": true,
+      "ledger_index": "validated",
+      "type": "state"
+    }
+  ]
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```sh
+rippled account_objects rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf sponsored=true ledger_index=validated type=state
+```
+{% /tab %}
+
+{% /tabs %}
+
+### Response Format
+
+An example of a successful response:
+
+{% tabs %}
+
+{% tab label="WebSocket" %}
+```json
+{
+  "id": 1,
+  "result": {
+    "account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+    "account_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+        "PreviousTxnLgrSeq": 12345678,
+        "index": "ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890"
+      }
+    ],
+    "ledger_hash": "FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321",
+    "ledger_index": 56789012,
+    "validated": true
+  },
+  "status": "success",
+  "type": "response"
+}
+```
+{% /tab %}
+
+{% tab label="JSON-RPC" %}
+```json
+{
+  "result": {
+    "account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+    "account_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+        "PreviousTxnLgrSeq": 12345678,
+        "index": "ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890"
+      }
+    ],
+    "ledger_hash": "FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321",
+    "ledger_index": 56789012,
+    "validated": true,
+    "status": "success"
+  }
+}
+```
+{% /tab %}
+
+{% tab label="Commandline" %}
+```json
+{
+  "result": {
+    "account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+    "account_objects": [
+      {
+        "Balance": {
+          "currency": "USD",
+          "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+          "value": "100"
+        },
+        "Flags": 65536,
+        "HighLimit": {
+          "currency": "USD",
+          "issuer": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+          "value": "1000"
+        },
+        "HighNode": "0000000000000000",
+        "HighSponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "LedgerEntryType": "RippleState",
+        "LowLimit": {
+          "currency": "USD",
+          "issuer": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+          "value": "0"
+        },
+        "LowNode": "0000000000000000",
+        "PreviousTxnID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+        "PreviousTxnLgrSeq": 12345678,
+        "index": "ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890"
+      }
+    ],
+    "ledger_hash": "FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321FEDCBA0987654321",
+    "ledger_index": 56789012,
+    "validated": true,
+    "status": "success"
+  }
+}
+```
+{% /tab %}
+
+{% /tabs %}
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/sponsorship.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/sponsorship.md
@@ -1,0 +1,81 @@
+---
+seo: 
+  description: A Sponsorship object represents a sponsoring relationship between two accounts.
+labels:
+  - Fees
+  - Accounts
+  - Sponsorship
+status: not_enabled
+---
+# Sponsorship
+
+[[Source]](https://github.com/tequdev/rippled/blob/sponsor/include/xrpl/protocol/detail/ledger_entries.macro#L611-L624 "Source")
+
+A {% code-page-name /%} ledger entry represents a sponsoring relationship between a sponsor and a sponsee. This allows sponsors to _pre-fund_ sponsees, if they so desire.
+
+{% admonition type="info" name="Note" %}
+This object does not need to be created in order to sponsor accounts. It is an offered convenience, so that sponsors do not have to co-sign every sponsored transaction if they don't want to, especially for transaction fees. It also allows sponsors to set a maximum balance even if they still want to co-sign transactions.
+{% /admonition %}
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## Example JSON
+
+```json
+{
+  "LedgerEntryType": "Sponsorship",
+  "Flags": 0,
+  "Owner": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "Sponsee": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+  "FeeAmount": "1000000",
+  "MaxFee": "1000",
+  "ReserveCount": 5,
+  "OwnerNode": "0000000000000000",
+  "SponseeNode": "0000000000000000",
+  "PreviousTxnID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+  "PreviousTxnLgrSeq": 12345678
+}
+```
+
+## {% $frontmatter.seo.title %} Fields
+
+In addition to the [common ledger entry fields](./updated-ledger-entries.md#common-ledger-entry-updates#common-ledger-entry-fields), a {% code-page-name /%} entry has the following fields:
+
+| Field Name          | JSON Type | [Internal Type][] | Required? | Description |
+| :------------------ | :-------- | :---------------- | :-------- | :---------- |
+| `FeeAmount`         | String    | Amount            | No        | The remaining amount of XRP that the sponsor has provided for the sponsee to use for transaction fees. |
+| `MaxFee`            | String    | Amount            | No        | The maximum fee per transaction that the sponsor will cover. This field helps prevent excessive draining of the pre-funded fee pool. If the sponsee submits a transaction with a fee exceeding this value, the transaction fails. |
+| `Owner`             | String    | AccountID         | Yes       | The address of the sponsor account. This account pays the reserve for this object. |
+| `OwnerNode`         | String    | UInt64            | Yes       | A hint indicating which page of the sponsor's owner directory links to this object, in case the directory consists of multiple pages. |
+| `PreviousTxnID`     | String    | Hash256           | Yes       | The identifying hash of the transaction that most recently modified this entry. |
+| `PreviousTxnLgrSeq` | Number    | UInt32            | Yes       | The [ledger index](https://xrpl.org/docs/references/protocol/data-types/basic-data-types#ledger-index) of the ledger that contains the transaction that most recently modified this object. |
+| `ReserveCount`      | Number    | UInt32            | No        | The remaining number of owner reserves the sponsor has pre-funded for the sponsee. |
+| `Sponsee`           | String    | AccountID         | Yes       | The address of the sponsee account associated with this relationship. |
+| `SponseeNode`       | String    | UInt64            | Yes       | A hint indicating which page of the sponsee's owner directory links to this object, in case the directory consists of multiple pages. |
+
+## {% $frontmatter.seo.title %} Flags
+
+A {% code-page-name /%} entry can have the following flags:
+
+| Flag Name                             | Flag Value   | Description |
+| :------------------------------------ | :----------- | :---------- |
+| `lsfSponsorshipRequireSignForFee`     | `0x00010000` | If enabled, every transaction that uses this sponsorship for fees requires a signature from the sponsor. If disabled, no signature is necessary, as the existence of the {% code-page-name /%} object is sufficient. |
+| `lsfSponsorshipRequireSignForReserve` | `0x00020000` | If enabled, every transaction that uses this sponsorship for reserves requires a signature from the sponsor. If disabled, no signature is necessary, as the existence of the {% code-page-name /%} object is sufficient. |
+
+## Deleting a Sponsorship Object
+
+Either the sponsor or the sponsee can delete a {% code-page-name /%} object using the [SponsorshipSet transaction][] with the `tfDeleteObject` flag enabled.
+
+{% admonition type="warning" name="Warning" %}
+The {% code-page-name /%} object is a [deletion blocker](https://xrpl.org/docs/concepts/accounts/deleting-accounts#requirements). A sponsor cannot delete their account until all their {% code-page-name /%} objects are removed.
+{% /admonition %}
+
+## Sponsorship ID Format
+
+The ID of a {% code-page-name /%} entry is the [SHA-512Half](https://xrpl.org/docs/references/protocol/data-types/basic-data-types#hashes) of the following values, concatenated in order:
+
+1. The Sponsorship space key (`0x003E`)
+2. The AccountID of the sponsor (`Owner` field)
+3. The AccountID of the `Sponsee`
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
@@ -30,6 +30,10 @@ The `Sponsor` field may appear on the following ledger entry types:
 - `DID`
 - Any other ledger entry type that contributes to an account's owner reserve.
 
+{% admonition type="info" name="Note" %}
+NFTs are stored in `NFTokenPage` objects, not as individual ledger entries. When sponsoring NFTs, the `Sponsor` field applies to the entire `NFTokenPage`, which can hold up to 32 NFTs. All NFTs within a sponsored page share the **same** sponsor.
+{% /admonition %}
+
 ## AccountRoot Updates
 
 ### Example JSON

--- a/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
@@ -1,0 +1,106 @@
+# Updated Ledger Entries
+
+This page describes changes to existing ledger entry types for Sponsored Fees and Reserves.
+
+## Common Ledger Entry Updates
+
+### Common Ledger Entry Fields
+
+A new `Sponsor` field is added to the [common ledger entry fields](https://xrpl.org/docs/references/protocol/ledger-data/common-fields):
+
+| Field Name | JSON Type | [Internal Type][] | Required? | Description |
+| :--------- | :-------- | :---------------- | :-------- | :---------- |
+| `Sponsor`  | String    | AccountID         | No        | The sponsor paying the owner reserve for this ledger object. When present, this indicates that the reserve burden for this object has shifted from the owner to the sponsor. |
+
+The `Sponsor` field may appear on the following ledger entry types:
+
+- `AccountRoot`
+- `Offer`
+- `Escrow`
+- `Check`
+- `PayChannel`
+- `DepositPreauth`
+- `Ticket`
+- `NFTokenPage`
+- `NFTokenOffer`
+- `AMM`
+- `Bridge`
+- `XChainOwnedClaimID`
+- `XChainOwnedCreateAccountClaimID`
+- `DID`
+- Any other ledger entry type that contributes to an account's owner reserve.
+
+## AccountRoot Updates
+
+### Example JSON
+
+```json
+{
+  "LedgerEntryType": "AccountRoot",
+  "Account": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+  "Balance": "100000000", // 100 XRP in drops
+  "OwnerCount": 5,
+  "Sponsor": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "SponsoredOwnerCount": 2,
+  "SponsoringOwnerCount": 1,
+  "SponsoringAccountCount": 1,
+  "PreviousTxnID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+  "PreviousTxnLgrSeq": 12345679
+}
+```
+
+### AccountRoot Fields
+
+[AccountRoot ledger entries](https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/accountroot) can include the following new fields:
+
+| Field Name               | JSON Type | [Internal Type][] | Required? | Description |
+| :----------------------- | :-------- | :---------------- | :-------- | :---------- |
+| `Sponsor`                | String    | AccountID         | No        | The sponsor paying the account reserve for this account. |
+| `SponsoredOwnerCount`    | Number    | UInt32            | No        | The number of objects this account owns that are sponsored by another account. |
+| `SponsoringOwnerCount`   | Number    | UInt32            | No        | The number of objects this account is sponsoring the reserve for. |
+| `SponsoringAccountCount` | Number    | UInt32            | No        | The number of accounts this account is sponsoring the account reserve for. |
+
+## RippleState Updates
+
+### Example JSON
+
+```json
+{
+  "LedgerEntryType": "RippleState",
+  "Balance": {
+    "currency": "USD",
+    "issuer": "rLowAccountAddressXXXXXXXXXXXXXXX",
+    "value": "-10"
+  },
+  "HighLimit": {
+    "currency": "USD",
+    "issuer": "rHighAccountAddressXXXXXXXXXXXXXX",
+    "value": "100"
+  },
+  "LowLimit": {
+    "currency": "USD",
+    "issuer": "rLowAccountAddressXXXXXXXXXXXXXXX",
+    "value": "0"
+  },
+  "HighSponsor": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "LowSponsor": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "Flags": 262144,
+  "HighNode": "0000000000000000",
+  "LowNode": "0000000000000000",
+  "PreviousTxnID": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+  "PreviousTxnLgrSeq": 12345680
+}
+```
+
+### RippleState Fields
+
+[RippleState ledger entries](https://xrpl.org/docs/references/protocol/ledger-data/ledger-entry-types/ripplestate) can include the following new fields:
+
+| Field Name    | JSON Type | [Internal Type][] | Required? | Description |
+| :------------ | :-------- | :---------------- | :-------- | :---------- |
+| `HighSponsor` | String    | AccountID         | No        | The sponsor paying the reserve on behalf of the _high account_ on the trust line. |
+| `LowSponsor`  | String    | AccountID         | No        | The sponsor paying the reserve on behalf of the _low account_ on the trust line. |
+
+The `HighSponsor` and `LowSponsor` fields are necessary because bidirectional trust lines may have the reserve held by two accounts.
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
@@ -4,8 +4,6 @@ This page describes changes to existing ledger entry types for Sponsored Fees an
 
 ## Common Ledger Entry Updates
 
-### Common Ledger Entry Fields
-
 A new `Sponsor` field is added to the [common ledger entry fields](https://xrpl.org/docs/references/protocol/ledger-data/common-fields):
 
 | Field Name | JSON Type | [Internal Type][] | Required? | Description |
@@ -105,6 +103,6 @@ NFTs are stored in `NFTokenPage` objects, not as individual ledger entries. When
 | `HighSponsor` | String    | AccountID         | No        | The sponsor paying the reserve on behalf of the _high account_ on the trust line. |
 | `LowSponsor`  | String    | AccountID         | No        | The sponsor paying the reserve on behalf of the _low account_ on the trust line. |
 
-The `HighSponsor` and `LowSponsor` fields are necessary because bidirectional trust lines may have the reserve held by two accounts.
+The `HighSponsor` and `LowSponsor` fields exist because bidirectional trust lines may have the reserve held by two accounts.
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshipset.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshipset.md
@@ -1,0 +1,80 @@
+---
+seo:
+    description: Create, update, or delete a Sponsorship ledger entry on the XRP Ledger.
+labels:
+    - Fees
+    - Accounts
+    - Sponsorship
+status: not_enabled
+---
+# SponsorshipSet
+
+[[Source]](https://github.com/tequdev/rippled/blob/sponsor/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp)
+
+Create, update, or delete a [Sponsorship ledger entry][] on the XRP Ledger.
+
+{% admonition type="warning" name="Warning" %}
+This transaction requires that you specify either the **CounterpartySponsor** or **Sponsee**, but not both.
+{% /admonition %}
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## Example JSON
+
+```json
+{
+  "TransactionType": "SponsorshipSet",
+  "Account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+  "Sponsee": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+  "FeeAmount": "1000000",
+  "MaxFee": "1000",
+  "ReserveCount": 5,
+  "Fee": "12",
+  "Sequence": 42
+}
+```
+
+## {% $frontmatter.seo.title %} Fields
+
+In addition to the [common fields](./updated-common-transaction-fields.md#common-transaction-updates#common-transaction-fields), {% code-page-name /%} transactions use the following fields:
+
+| Field Name            | JSON Type | [Internal Type][] | Required? | Description |
+| :-------------------- | :-------- | :---------------- | :-------- | :---------- |
+| `CounterpartySponsor` | String    | AccountID         | No        | The sponsor associated with this relationship. This account also pays for the reserve of this object. If this field is included, the `Account` is assumed to be the sponsee. |
+| `FeeAmount`           | String    | Amount            | No        | The remaining amount of XRP that the sponsor has provided for the sponsee to use for fees. This value replaces what is currently in the `Sponsorship.FeeAmount` field, if it exists. |
+| `MaxFee`              | String    | Amount            | No        | The maximum fee per transaction that will be sponsored. This prevents abuse or excessive draining of the sponsored fee pool. |
+| `ReserveCount`        | Number    | UInt32            | No        | The remaining amount of reserves that the sponsor has provided for the sponsee to use. This value replaces what is currently in the `Sponsorship.ReserveCount` field, if it exists. |
+| `Sponsee`             | String    | AccountID         | No        | The sponsee associated with this relationship. If this field is included, the `Account` is assumed to be the sponsor. |
+
+## {% $frontmatter.seo.title %} Flags
+
+{% code-page-name /%} transactions support additional values in the `Flags` field, as follows:
+
+| Flag Name                                   | Hex Value    | Decimal Value | Description |
+| :------------------------------------------ | :----------- | :------------ | :---------- |
+| `tfSponsorshipSetRequireSignForFee`         | `0x00010000` | 65536         | Adds the restriction that every use of this sponsor for sponsoring fees requires a signature from the sponsor. |
+| `tfSponsorshipClearRequireSignForFee`       | `0x00020000` | 131072        | Removes the restriction that every use of this sponsor for sponsoring fees requires a signature from the sponsor. |
+| `tfSponsorshipSetRequireSignForReserve`     | `0x00040000` | 262144        | Adds the restriction that every use of this sponsor for sponsoring reserves requires a signature from the sponsor. |
+| `tfSponsorshipClearRequireSignForReserve`   | `0x00080000` | 524288        | Removes the restriction that every use of this sponsor for sponsoring reserves requires a signature from the sponsor. |
+| `tfDeleteObject`                            | `0x00100000` | 1048576       | Deletes the `Sponsorship` ledger object. When enabled, no other fields or flag-setting fields may be specified. Deleting returns any remaining XRP in `FeeAmount` to the sponsor's account. |
+
+## Deleting a Sponsorship Object
+
+To delete a `Sponsorship` object, the sponsor or sponsee submits a {% code-page-name /%} transaction with the `tfDeleteObject` flag enabled. Any remaining XRP in `FeeAmount` is returned to the sponsor's account upon deletion.
+
+Deleting the `Sponsorship` object only removes the pre-funded fee and reserve arrangement between the sponsor and sponsee. Ledger entries that were previously created using sponsored reserves retain their `Sponsor` field and remain sponsored. To transfer or dissolve sponsorship for those existing ledger entries, use the [SponsorshipTransfer transaction][].
+
+## Error Cases
+
+Besides errors that can occur for all transactions, {% code-page-name /%} transactions can result in the following [transaction result codes](https://xrpl.org/docs/references/protocol/transactions/transaction-results):
+
+| Error Code        | Description |
+| :---------------- | :---------- |
+| `tecNO_DST`       | The sponsor or sponsee account does not exist on the ledger. |
+| `tecNO_ENTRY`     | The `tfDeleteObject` flag is enabled but the `Sponsorship` object does not exist. |
+| `tecUNFUNDED`     | The sponsor does not have sufficient XRP to fund the `FeeAmount` or to cover the reserve for the `Sponsorship` object. |
+| `temBAD_AMOUNT`   | An amount field is invalid. This can occur when:<ul><li>`FeeAmount` is negative or not denominated in XRP.</li><li>`MaxFee` is negative or not denominated in XRP.</li></ul> |
+| `temINVALID_FLAG` | The transaction has invalid flags. This can occur when:<ul><li>Conflicting flags are enabled, such as both `tfSponsorshipSetRequireSignForFee` and `tfSponsorshipClearRequireSignForFee`.</li><li>The `tfDeleteObject` flag is enabled with flags that modify the object's settings.</li></ul> |
+| `temMALFORMED`    | The transaction is malformed. This can occur when:<ul><li>The `Account` is not equal to either the sponsor or sponsee.</li><li>Both `CounterpartySponsor` and `Sponsee` are specified.</li><li>Neither `CounterpartySponsor` nor `Sponsee` is specified.</li><li>The sponsee attempts to create or update the object. Only the sponsor can create or update.</li><li>The `tfDeleteObject` flag is enabled and `FeeAmount`, `MaxFee`, or `ReserveCount` is specified.</li><li>The sponsor and sponsee are the same account.</li></ul> |
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
@@ -69,22 +69,6 @@ When successful:
 - For objects, the owner's `SponsoredOwnerCount` is also incremented.
 {% /tab %}
 
-{% tab label="End Sponsorship" %}
-Use the `tfSponsorshipEnd` flag to dissolve an existing sponsorship. Either the sponsor or the sponsee can submit the transaction with this configuration. The reserve burden returns to the object or account owner.
-
-To submit a transaction for this scenario:
-
-- Provide the `ObjectID` when ending sponsorship for an object. Omit when ending sponsorship for an account.
-- The target object or account must currently be sponsored.
-- Do not include the `Sponsor` and the `SponsorFlags.spfSponsorReserve` flag.
-
-When successful:
-
-- The `Sponsor` field is removed from the object or account.
-- The old sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is decremented.
-- For objects, the owner's `SponsoredOwnerCount` is also decremented.
-{% /tab %}
-
 {% tab label="Reassign Sponsorship" %}
 Use the `tfSponsorshipReassign` flag to transfer an existing sponsorship to a new sponsor specified in the `Sponsor` field. Only the sponsee can submit the transaction with this configuration.
 
@@ -101,6 +85,22 @@ When successful:
 - The `Sponsor` field is updated to the new sponsor.
 - The old sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is decremented.
 - The new sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is incremented.
+{% /tab %}
+
+{% tab label="End Sponsorship" %}
+Use the `tfSponsorshipEnd` flag to dissolve an existing sponsorship. Either the sponsor or the sponsee can submit the transaction with this configuration. The reserve burden returns to the object or account owner.
+
+To submit a transaction for this scenario:
+
+- Provide the `ObjectID` when ending sponsorship for an object. Omit when ending sponsorship for an account.
+- The target object or account must currently be sponsored.
+- Do not include the `Sponsor` and the `SponsorFlags.spfSponsorReserve` flag.
+
+When successful:
+
+- The `Sponsor` field is removed from the object or account.
+- The old sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is decremented.
+- For objects, the owner's `SponsoredOwnerCount` is also decremented.
 {% /tab %}
 
 {% /tabs %}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
@@ -1,0 +1,120 @@
+---
+seo:
+    description: Create, transfer, or end reserve sponsorship for a ledger object or account.
+labels:
+    - Fees
+    - Accounts
+    - Sponsorship
+status: not_enabled
+---
+# SponsorshipTransfer
+
+[[Source]](https://github.com/tequdev/rippled/blob/sponsor/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp)
+
+Create, transfer, or end reserve sponsorship for a ledger object or account. The transaction can be submitted by the sponsor or sponsee, depending on the required operation. See [Sponsorship Scenarios](#sponsorship-scenarios) for details on each operation.
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## Example JSON
+
+```json
+{
+    "TransactionType": "SponsorshipTransfer",
+    "Account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf",
+    "ObjectID": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+    "Flags": 2,
+    "Fee": "12",
+    "Sequence": 43
+}
+```
+
+## {% $frontmatter.seo.title %} Fields
+
+In addition to the [common fields](./updated-common-transaction-fields.md#common-transaction-updates#common-transaction-fields), {% code-page-name /%} transactions use the following fields:
+
+| Field Name | JSON Type | [Internal Type][] | Required? | Description |
+| :--------- | :-------- | :---------------- | :-------- | :---------- |
+| `ObjectID` | String    | Hash256           | No        | The ID of the ledger object to transfer sponsorship. Required if the transaction is dealing with a sponsored object, rather than a sponsored account. If omitted, the transaction refers to the `Account` sending the transaction. |
+| `Sponsee`  | String    | AccountID         | No        | The wallet address of the sponsee account. Required if the sponsor is ending a sponsorship on behalf of a sponsee. If omitted, the `Account` field is assumed to be the sponsee. |
+
+## {% $frontmatter.seo.title %} Flags
+
+{% code-page-name /%} transactions support additional values in the `Flags` field, as follows:
+
+| Flag Name               | Hex Value    | Decimal Value | Description |
+| :---------------------- | :----------- | :------------ | :---------- |
+| `tfSponsorshipEnd`      | `0x00000001` | 1             | End an existing sponsorship. The reserve burden returns to the object's owner. |
+| `tfSponsorshipCreate`   | `0x00000002` | 2             | Create a new sponsorship for an unsponsored object or account. |
+| `tfSponsorshipReassign` | `0x00000004` | 4             | Transfer an existing sponsorship to a new sponsor. |
+
+## Sponsorship Scenarios
+
+{% tabs %}
+
+{% tab label="Create Sponsorship" %}
+Use the `tfSponsorshipCreate` flag to sponsor an object or account. Only the sponsee can submit the transaction with this configuration. The reserve sponsorship transfers to the account specified in the `Sponsor` field.
+
+To submit a transaction for this scenario:
+
+- Include the `ObjectID` field when sponsoring an object. Omit when sponsoring an account.
+- The target object or account must not currently be sponsored.
+- Provide the `Sponsor` field and the `SponsorFlags.spfSponsorReserve` flag.
+- Include the `SponsorSignature` when sponsoring an account. This is optional when sponsoring an object.
+- Do not include the `Sponsee` field.
+
+When successful:
+
+- The `Sponsor` field is set on the object or account.
+- The new sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is incremented.
+- For objects, the owner's `SponsoredOwnerCount` is also incremented.
+{% /tab %}
+
+{% tab label="End Sponsorship" %}
+Use the `tfSponsorshipEnd` flag to dissolve an existing sponsorship. Either the sponsor or the sponsee can submit the transaction with this configuration. The reserve burden returns to the object or account owner.
+
+To submit a transaction for this scenario:
+
+- Provide the `ObjectID` when ending sponsorship for an object. Omit when ending sponsorship for an account.
+- The target object or account must currently be sponsored.
+- Do not include the `Sponsor` and the `SponsorFlags.spfSponsorReserve` flag.
+
+When successful:
+
+- The `Sponsor` field is removed from the object or account.
+- The old sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is decremented.
+- For objects, the owner's `SponsoredOwnerCount` is also decremented.
+{% /tab %}
+
+{% tab label="Reassign Sponsorship" %}
+Use the `tfSponsorshipReassign` flag to transfer an existing sponsorship to a new sponsor specified in the `Sponsor` field. Only the sponsee can submit the transaction with this configuration.
+
+To submit a transaction for this scenario:
+
+- Include the `ObjectID` field when reassigning sponsorship of an object. Omit when reassigning sponsorship of an account.
+- The target object or account must currently be sponsored.
+- Provide the `Sponsor` field with the `SponsorFlags.spfSponsorReserve` flag.
+- Include the `SponsorSignature` when sponsoring an account. This is optional when sponsoring an object.
+- Do not include the `Sponsee` field.
+
+When successful:
+
+- The `Sponsor` field is updated to the new sponsor.
+- The old sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is decremented.
+- The new sponsor's `SponsoringOwnerCount` or `SponsoringAccountCount` is incremented.
+{% /tab %}
+
+{% /tabs %}
+
+## Error Cases
+
+Besides errors that can occur for all transactions, {% code-page-name /%} transactions can result in the following [transaction result codes](https://xrpl.org/docs/references/protocol/transactions/transaction-results):
+
+| Error Code                | Description |
+| :------------------------ | :---------- |
+| `tecINSUFFICIENT_RESERVE` | The owner or new sponsor does not have sufficient XRP to cover the reserve for this object or account. |
+| `tecNO_ENTRY`             | The `ObjectID` is specified but does not exist on the ledger. |
+| `tecNO_PERMISSION`        | The transaction lacks the required permissions. This can occur when:<ul><li>The submitter is not the current sponsor or owner when ending a sponsorship.</li><li>The submitter is not the owner when creating or reassigning a sponsorship.</li><li>The object or account is already sponsored when creating a sponsorship.</li><li>The object or account is not sponsored when reassigning or ending a sponsorship.</li><li>The `Sponsor` field is missing when creating or reassigning a sponsorship.</li><li>The `Sponsor` field is present when ending a sponsorship.</li></ul> |
+| `temINVALID_FLAG`         | The transaction has invalid flags. This can occur when:<ul><li>The transaction does not have exactly one of `tfSponsorshipCreate`, `tfSponsorshipReassign`, or `tfSponsorshipEnd` set.</li><li>The `spfSponsorReserve` flag is missing when creating or reassigning a sponsorship.</li><li>The `spfSponsorReserve` flag is present when ending a sponsorship.</li></ul> |
+| `temMALFORMED`            | The transaction is malformed. This can occur when:<ul><li>The `Sponsee` field is present when creating or reassigning a sponsorship.</li><li>The `Sponsee` field is the same as the `Account` field.</li><li>Sponsoring an account without providing the `SponsorSignature` field.</li></ul> |
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-common-transaction-fields.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-common-transaction-fields.md
@@ -1,0 +1,77 @@
+# Updated Common Transaction Fields
+
+This page describes the new fields and flags added to all transactions to support Sponsored Fees and Reserves. These fields extend the existing [common transaction fields](https://xrpl.org/docs/references/protocol/transactions/common-fields).
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## New Common Fields
+
+The following fields are added to the common transaction fields:
+
+| Field Name                              | JSON Type | [Internal Type][] | Required? | Description  |
+| :-------------------------------------- | :-------- | :---------------- | :-------- | :----------- |
+| `Sponsor`                               | String    | AccountID         | No        | The address of the sponsoring account. |
+| [`SponsorFlags`](#sponsorflags)         | Number    | UInt32            | No        | Flags indicating the type of sponsorship. If included, at least one flag must be set. |
+| [`SponsorSignature`](#sponsorsignature) | Object    | Object            | No        | Contains the signing information for the sponsorship. |
+
+### SponsorFlags
+
+The `SponsorFlags` field allows the user to specify which sponsorship type(s) they wish to participate in.
+
+| Flag Name           | Hex Value    | Decimal Value | Description |
+| :------------------ | :----------- | :------------ | :---------- |
+| `spfSponsorFee`     | `0x00000001` | 1             | Sponsoring the fee of the transaction. |
+| `spfSponsorReserve` | `0x00000002` | 2             | Sponsoring the reserve for any objects created in the transaction. |
+
+{% admonition type="info" name="Note" %}
+Both flags can be used together in a single transaction. At least one flag must be set if the `Sponsor` field is included.
+{% /admonition %}
+
+### SponsorSignature
+
+The `SponsorSignature` field is an object containing the sponsor's signing information.
+
+| Field Name      | JSON Type | [Internal Type][] | Required? | Description  |
+| :-------------- | :-------- | :---------------- | :-------- | :----------- |
+| `SigningPubKey` | String    | Blob              | No        | The `SigningPubKey` for the `Sponsor`, if single-signing. |
+| `TxnSignature`  | String    | Blob              | No        | A signature of the transaction from the sponsor, to indicate their approval of this transaction, if single-signing. |
+| `Signers`       | Array     | Array             | No        | An array of signatures of the transaction from the sponsor's signers to indicate their approval of this transaction, if the sponsor is [multi-signing](https://xrpl.org/multi-signing.html). |
+
+These fields are not included in transaction signatures, though they are still included in the stored transaction. There is no additional transaction fee for using `TxnSignature`.
+
+{% admonition type="info" name="Note" %}
+A sponsor signature is only required if no pre-funded `Sponsorship` object exists, or if the `lsfSponsorshipRequireSignForFee` or `lsfSponsorshipRequireSignForReserve` flags are enabled on the [Sponsorship ledger entry][].
+{% /admonition %}
+
+#### Transaction Fee Calculation
+
+If the `SponsorSignature.Signers` field is necessary, the total fee of the transaction will be increased due to the extra signatures that need to be processed. This is similar to the additional fees for multi-signing.
+
+The total fee calculation for signatures is:
+
+```text
+(1 + |tx.Signers| + |tx.SponsorSignature.Signers|) × base_fee (+ any transaction-specific fees)
+```
+
+## Error Cases
+<!-- TODO: When porting to xrpl.org, move these error codes to the Transaction Results section. -->
+
+The following failure conditions have been added to transactions using the sponsorship fields:
+
+| Error Code                | Description |
+| :------------------------ | :---------- |
+| `temDISABLED`             | The Sponsor amendment is not enabled. |
+| `temMALFORMED`            | The transaction is malformed. This can occur when:<ul><li>The sponsor and the transaction sender are the same account.</li><li>The transaction includes a sponsor signature but does not specify a sponsor.</li><li>The sponsor signature contains an invalid combination of signing fields.</li></ul> |
+| `temINVALID_FLAG`         | The transaction has invalid flags. This can occur when:<ul><li>The `SponsorFlags` field contains invalid flags. Valid flags are `spfSponsorFee` and `spfSponsorReserve`.</li><li>The transaction includes `SponsorFlags` but does not specify a sponsor.</li><li>The `SponsorFlags` field is included but set to zero.</li></ul> |
+| `terNO_ACCOUNT`           | The sponsor account does not exist. |
+| `tefBAD_AUTH`             | The sponsor signature is invalid. The public key does not match the sponsor account's master key or regular key, or the key type is unknown. |
+| `tefNOT_MULTI_SIGNING`    | The sponsor account does not have a signer list. |
+| `tefBAD_SIGNATURE`        | The sponsor multi-signature is invalid. A signer is not in the signer list, a public key is invalid, or a signature is invalid. |
+| `tefBAD_QUORUM`           | The sponsor multi-signature does not meet the required quorum. |
+| `telINSUF_FEE_P`          | The sponsor account does not have enough XRP to pay the transaction fee. |
+| `terNO_SPONSORSHIP`       | The transaction requires a sponsor signature, but none was provided. This can occur when:<ul><li>No pre-funded `Sponsorship` object exists.</li><li>The `Sponsorship` object requires a signature for fee sponsorship.</li><li>The `Sponsorship` object requires a signature for reserve sponsorship.</li></ul> |
+| `terINSUF_FEE_B`          | The pre-funded `Sponsorship` object does not have enough XRP in `FeeAmount`, or the transaction fee exceeds `MaxFee`. |
+| `tecINSUFF_FEE`           | The pre-funded `Sponsorship` object does not have enough XRP in `FeeAmount`, or the transaction fee exceeds `MaxFee`. This error occurs on a closed ledger when the balance is non-zero. |
+| `tecINSUFFICIENT_RESERVE` | The sponsor does not have enough XRP to cover the reserve, or the pre-funded `Sponsorship` object does not have enough remaining `ReserveCount`. |
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-transactions.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-transactions.md
@@ -1,0 +1,69 @@
+# Updated Transactions
+
+This page describes the changes to existing transaction types introduced by Sponsored Fees and Reserves.
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## Payment Transaction Updates
+
+### Example JSON
+
+```json
+{
+  "TransactionType": "Payment",
+  "Account": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf", // The new sponsored account
+  "Destination": "rfkDkFai4jUfCvAJiZ5Vm7XvvWjYvDqeYo",
+  "Amount": "1",  // 1 drop, the minimum
+  "Flags": 524288, // tfSponsorCreatedAccount
+  "Fee": "10",
+  "Sequence": 3
+}
+```
+
+### Payment Flags
+
+A new flag is added to the [Payment transaction](https://xrpl.org/docs/references/protocol/transactions/types/payment) for sponsoring new accounts:
+
+| Flag Name                 | Hex Value    | Decimal Value | Description |
+| :------------------------ | :----------- | :------------ | :---------- |
+| `tfSponsorCreatedAccount` | `0x00080000` | 524288        | This flag is only valid if the Payment is used to create an account. If it is enabled, the created account will be sponsored by the `Account` submitting the transaction. |
+
+### Error Cases
+
+When `tfSponsorCreatedAccount` is enabled, the following additional error cases apply:
+
+| Error Code                 | Description |
+| :------------------------- | :---------- |
+| `temINVALID_FLAG`          | `tfNoRippleDirect`, `tfPartialPayment`, or `tfLimitQuality` are enabled. The `tfSponsorCreatedAccount` flag cannot be combined with these flags. |
+| `temBAD_AMOUNT`            | The `Amount` specifies a non-XRP currency. |
+| `tecNO_SPONSOR_PERMISSION` | The `Destination` already exists. This flag is only valid when creating a new account. |
+| `tecNO_DST_INSUF_XRP`      | The `Account` does not have enough XRP to cover the account reserve requirement for the sponsored account. |
+
+## AccountDelete Transaction Updates
+
+The [AccountDelete transaction](https://xrpl.org/docs/references/protocol/transactions/types/accountdelete) adds new constraints for sponsored accounts. If the account being deleted has a `Sponsor` field, the `Destination` must equal the `Sponsor` value to ensure the sponsor can recoup their reserve.
+
+On successful deletion, the sponsor's `SponsoringAccountCount` is decremented by 1. If the deleted account had a `SponsoredOwnerCount` field, the sponsor's `SponsoringOwnerCount` is also decremented by that value.
+
+### Example JSON
+
+```json
+{
+  "TransactionType": "AccountDelete",
+  "Account": "rWYkbWkCeg8dP6rXALnjgZSjjLyih5NXm",
+  "Destination": "rN7n7otQDd6FczFgLdlqtyMVrn3HMfXpf", // The sponsor
+  "Fee": "5000000",
+  "Sequence": 2470665
+}
+```
+
+### Error Cases
+
+The following additional error cases apply for `AccountDelete` transactions:
+
+| Error Code                 | Description |
+| :------------------------- | :---------- |
+| `tecNO_SPONSOR_PERMISSION` | The `AccountRoot` has a `Sponsor` field, but the `Destination` is not equal to the sponsor. Sponsored account funds must go to the sponsor. |
+| `tecHAS_OBLIGATIONS` | The `AccountRoot` has a non-zero `SponsoringOwnerCount` or `SponsoringAccountCount` field. The account cannot be deleted until those sponsorships are transferred or dissolved. |
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-68-sponsored-fees-and-reserves/references/updated-permission-values.md
+++ b/docs/xls-68-sponsored-fees-and-reserves/references/updated-permission-values.md
@@ -1,0 +1,14 @@
+# Updated Permission Values
+
+Sponsored Fees and Reserves introduces two new [granular permissions](https://xrpl.org/docs/references/protocol/data-types/permission-values#granular-permissions).
+
+_(Requires the [Sponsor amendment][] {% not-enabled /%})_
+
+## Granular Permissions
+
+| Numeric Value | Name             | Transaction Type | Description |
+| :------------ | :--------------- | :--------------- | :---------- |
+| 65549         | `SponsorFee`     | SponsorshipSet   | Can set or modify fee sponsorship fields (`FeeAmount`, `MaxFee`) and flags on a Sponsorship object. |
+| 65550         | `SponsorReserve` | SponsorshipSet   | Can set or modify reserve sponsorship fields (`ReserveCount`) and flags on a Sponsorship object. |
+
+{% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -78,6 +78,13 @@ export default function Page() {
               Learn more
             </Button>
           </Card>
+
+          <Card title="Sponsored Fees and Reserves" to="docs/xls-68-sponsored-fees-and-reserves/">
+            <p>Enable sponsors to pay transaction fees and reserves on behalf of other accounts, reducing barriers to entry on the XRP Ledger.</p>
+            <Button size="large" variant="primary">
+              Learn more
+            </Button>
+          </Card>
         </Cards>
       </LandingContainer>
 

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -46,3 +46,31 @@
       expanded: false
       items:
         - page: docs/xls-100-smart-escrows/concepts/programmability.md
+    - group: XLS-68 Sponsored Fees and Reserves
+      page: docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
+      items:
+        - group: Concepts
+          expanded: false
+          items:
+            - page: docs/xls-68-sponsored-fees-and-reserves/concepts/sponsored-fees-and-reserves.md
+        - group: References
+          expanded: false
+          items:
+            - group: Ledger Entries
+              expanded: false
+              items:
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/sponsorship.md
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/ledger-entries/updated-ledger-entries.md
+            - group: Transactions
+              expanded: false
+              items:
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshipset.md
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/transactions/sponsorshiptransfer.md
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-common-transaction-fields.md
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/transactions/updated-transactions.md
+            - group: APIs
+              expanded: false
+              items:
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/apis/account_sponsoring.md
+                - page: docs/xls-68-sponsored-fees-and-reserves/references/apis/updated-apis.md
+            - page: docs/xls-68-sponsored-fees-and-reserves/references/updated-permission-values.md


### PR DESCRIPTION
Adds Concept and Reference documentation for Sponsored Fees and Reserves.
Preview here: https://opensource-ripple-com--sponsored-fees-and-reserves.preview.redocly.app/docs/xls-68-sponsored-fees-and-reserves

Tutorials will be added in a separate PR.

XLS Spec PR (latest updates): https://github.com/XRPLF/XRPL-Standards/pull/465
`rippled` PR: https://github.com/XRPLF/rippled/pull/5887