### PR TITLE
Add landing page for XLS-82-MPT DEX

### DIFF
--- a/docs/xls-82-mpt-dex/index.page.tsx
+++ b/docs/xls-82-mpt-dex/index.page.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { 
+  LandingContainer, 
+  LandingLayout, 
+  ButtonToXRPL,
+  FeatureHeader,
+  FeatureContent
+} from "../../components/landing";
+import { AmendmentTracker } from "../../components/AmendmentTracker";
+import { Button } from "@redocly/theme";
+import { Card } from '@redocly/theme/markdoc/components/Cards/Card';
+import { Cards } from '@redocly/theme/markdoc/components/Cards/Cards';
+
+export const frontmatter = {
+  seo: {
+    title: 'XLS-82 MPT DEX Integration',
+    description: "Adds Multi-Purpose Token (MPT) support for the XRPL decentralized exchange, including offers, cross-currency payments, checks, and AMM."
+  }
+};
+
+export default function Page() {
+  const KEY_DATE_EVENTS = [
+    "XLS Spec Live",
+    "Available to Test on Devnet",
+    "Open for Voting on Mainnet", 
+    "Vote Consensus"
+  ];
+
+  const [keyDates, setKeyDates] = React.useState(
+    KEY_DATE_EVENTS.map(event => ({ date: "🔄 Loading...", event }))
+  );
+
+  const handleKeyDatesUpdate = React.useCallback((newKeyDates: any[]) => {
+    setKeyDates(newKeyDates);
+  }, []);
+
+  return (
+    <LandingLayout>
+      <LandingContainer>
+        <FeatureHeader 
+          title="XLS-82 MPT DEX Integration"
+          subtitle="Trade Multi-Purpose Tokens on the XRP Ledger's decentralized exchange."
+        />
+
+        <FeatureContent 
+          description="The MPT DEX Integration amendment extends the XRPL's decentralized exchange to natively support Multi-Purpose Tokens (MPTs) as a tradeable asset class. MPTs can be paired with XRP, trust line tokens, or other MPTs across existing DEX transactions such as OfferCreate, Payment, AMM, and Checks."
+          keyDates={keyDates}
+        />
+
+        <AmendmentTracker 
+          amendmentId="BE2D87DF21B690ED1497B593FDC013CC04276302380B1BD50A033DCF8DEFB2EB"
+          xlsSpecDate="2024-09-19"
+          onKeyDatesUpdate={handleKeyDatesUpdate}
+        />
+
+        <Cards columns={2}>
+          <Card title="XLS Spec" to="https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0082-mpt-dex">
+            <p>Technical spec for the feature outlining requirements, design, and implementation details.</p>
+            <Button size="large" variant="primary">
+              Read the XLS Spec
+            </Button>
+          </Card>
+
+          <Card title="Documentation" to="https://xrpl-dev-portal--xls-82-mpt-dex.preview.redocly.app/docs/concepts/tokens/decentralized-exchange">
+            <p>Explore key concepts, find detailed references, and follow
+              step-by-step tutorials.</p>
+            <Button size="large" variant="primary">Read the Docs</Button>
+          </Card>
+        </Cards>
+      </LandingContainer>
+    </LandingLayout>
+  );
+}

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -85,6 +85,13 @@ export default function Page() {
               Learn more
             </Button>
           </Card>
+
+          <Card title="MPT DEX Integration" to="docs/xls-82-mpt-dex">
+            <p>Trade Multi-Purpose Tokens on the XRP Ledger's decentralized exchange across offers, payments, AMM, and checks.</p>
+            <Button size="large" variant="primary">
+              Learn more
+            </Button>
+          </Card>
         </Cards>
       </LandingContainer>
 

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -74,3 +74,5 @@
                 - page: docs/xls-68-sponsored-fees-and-reserves/references/apis/account_sponsoring.md
                 - page: docs/xls-68-sponsored-fees-and-reserves/references/apis/updated-apis.md
             - page: docs/xls-68-sponsored-fees-and-reserves/references/updated-permission-values.md
+
+    - page: docs/xls-82-mpt-dex/index.page.tsx


### PR DESCRIPTION
Adds a landing page for XLS-82 MPT DEX Integration docs.

Preview here: https://opensource-ripple-com--mpt-dex-landing-page.preview.redocly.app/

The MPT DEX docs link is a preview to the changes for xrpl.org - PR here: https://github.com/XRPLF/xrpl-dev-portal/pull/3537