### PR TITLE
Additional updates for Confidential Transfers

### DIFF
--- a/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
+++ b/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
@@ -75,7 +75,10 @@ The XRP Ledger relies on a set of ZKPs to validate confidential transactions wit
 
 - **Range proofs (Bulletproofs):** Prove that confidential amounts and post-transfer balances are non-negative and within a valid range, preventing overspending.
 
-Validators can verify confidential transactions by checking these cryptographic proofs without ever learning the underlying amounts. For example, when a holder sends tokens confidentially, the transaction includes encrypted values and proofs that mathematically demonstrate: the sender has sufficient balance, the amount is non-negative, and all encrypted copies of the transfer amount are consistent across the sender, receiver, issuer, and optional auditor.
+Validators can verify confidential transactions by checking these cryptographic proofs without ever learning the underlying amounts. For example, when a holder sends tokens confidentially, the transaction includes encrypted values and proofs that mathematically demonstrate:
+- The sender has sufficient balance.
+- The amount is non-negative.
+- All encrypted copies of the transfer amount are consistent across the sender, receiver, issuer, and optional auditor.
 
 Validators can only check the mathematical correctness of these proofs to ensure the transaction is valid, but cannot see the actual amounts involved.
 
@@ -167,7 +170,7 @@ Confidential transactions are larger and more computationally expensive than sta
 
 | Transaction                                  | Cost Before Load Scaling |
 |:---------------------------------------------|:------------------------ |
-| Confidential MPT Transaction (single-signed) | 10 drops × 10 |
+| Confidential MPT Transaction (single-signed) | 100 drops |
 | Confidential MPT Transaction (multi-signed)  | 10 drops × (10 + Number of Signatures Provided) |
 
 {% /admonition %}

--- a/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
+++ b/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
@@ -69,17 +69,13 @@ Issuer and auditor keys also cannot be changed or cleared once registered.
 
 The XRP Ledger relies on a set of ZKPs to validate confidential transactions without revealing balances or transfer amounts. The following proof types are used:
 
-- **Schnorr Proof of Knowledge**: Proves ownership of the private key is associated with the ElGamal public key.
+- **Schnorr Proof of Knowledge:** Proves ownership of the private key associated with an ElGamal public key. Required when a holder first registers their encryption key.
 
-- **Plaintext–ciphertext equality proofs:** Prove that a publicly known amount is correctly encrypted.
+- **Compact sigma proofs:** Cryptographic proofs, also called _AND-composed compact sigma proofs_, that bundle multiple zero-knowledge statements into a single fixed-size proof verified in one pass. Each confidential transaction type uses its own dedicated compact sigma proof to verify that encrypted values are consistent and correctly linked.
 
-- **Plaintext equality proofs:** Prove that multiple ciphertexts encrypt the same plaintext value, ensuring consistency of a confidential amount across the sender, receiver, issuer, and optional auditor.
+- **Range proofs (Bulletproofs):** Prove that confidential amounts and post-transfer balances are non-negative and within a valid range, preventing overspending.
 
-- **ElGamal–Pedersen equality proofs:** Link encrypted values to Pedersen commitments, allowing confidential amounts and balances to be used as inputs to range proofs without revealing the underlying values.
-
-- **Range proofs:** Prove that confidential amounts and post-transfer balances are within valid ranges, enforcing non-negativity and preventing overspending.
-
-Validators can verify confidential transactions by checking these cryptographic proofs without ever learning the underlying amounts. For example, when a holder sends tokens confidentially, the transaction includes encrypted values and proofs that mathematically demonstrate: the sender has sufficient balance, the amount is non-negative, and all encrypted amounts (holder, issuer, auditor) represent the same value.
+Validators can verify confidential transactions by checking these cryptographic proofs without ever learning the underlying amounts. For example, when a holder sends tokens confidentially, the transaction includes encrypted values and proofs that mathematically demonstrate: the sender has sufficient balance, the amount is non-negative, and all encrypted copies of the transfer amount are consistent across the sender, receiver, issuer, and optional auditor.
 
 Validators can only check the mathematical correctness of these proofs to ensure the transaction is valid, but cannot see the actual amounts involved.
 
@@ -147,7 +143,7 @@ Issuers can enable confidential features by setting the **Can Confidential Amoun
 
 By default, the privacy setting is mutable, so it can be toggled on and off as long as no confidential balances exist. Once confidential balances exist, the flag can no longer be disabled.
 
-When enabling confidential transfers, the issuer must also register their ElGamal public key, and if required, an auditor's public key.
+When enabling confidential transfers, the issuer must also register their ElGamal public key, and if required, an auditor's public key. The MPT issuance must have a transfer fee of **0**, since transfer fees cannot be applied to encrypted amounts. If the issuance has a non-zero transfer fee, the issuer must remove it before enabling confidential transfers.
 
 {% admonition type="warning" name="Warning" %}
 If the issuer enables the **Cannot Mutate Can Confidential Amount** flag at any time, the privacy setting becomes permanent and cannot be changed, even if no confidential balances exist.

--- a/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
+++ b/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
@@ -161,8 +161,15 @@ Token holders can manage confidential balances through four operations:
 
 - **Convert back to public:** The [ConfidentialMPTConvertBack transaction][] converts confidential tokens back to public form, making the amount visible on the ledger again.
 
+<!-- TODO: When moving to xrpl.org, add the confidential MPT fee rows to the Special Transaction Costs table: https://xrpl.org/docs/concepts/transactions/transaction-cost#special-transaction-costs -->
 {% admonition type="info" name="Note" %}
-Confidential transactions are larger and more computationally expensive than standard MPT transactions due to the inclusion of encrypted ciphertexts and ZKPs. However, they currently **don't** incur a higher transaction fee.
+Confidential transactions are larger and more computationally expensive than standard MPT transactions due to the inclusion of encrypted ciphertexts and ZKPs. They incur a higher [transaction cost](https://xrpl.org/docs/concepts/transactions/transaction-cost) than standard transactions:
+
+| Transaction                                  | Cost Before Load Scaling |
+|:---------------------------------------------|:------------------------ |
+| Confidential MPT Transaction (single-signed) | 10 drops × 10 |
+| Confidential MPT Transaction (multi-signed)  | 10 drops × (10 + Number of Signatures Provided) |
+
 {% /admonition %}
 
 ## Amendment Status

--- a/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
+++ b/docs/xls-96-confidential-transfers/concepts/confidential-transfers.md
@@ -138,6 +138,14 @@ While issuers retain the same [compliance controls](https://xrpl.org/docs/concep
 
 The [ConfidentialMPTClawback transaction][] allows issuers to claw back a holder's **entire** confidential balance. Off-chain, the issuer decrypts their mirror copy of the holder's balance and generates a cryptographic proof validating the plaintext amount. The issuer then submits the transaction with the plaintext amount and proof.
 
+{% admonition type="danger" name="Warning" %}
+The clawback proof can become stale if a holder's confidential balance changes between proof generation and validation. To ensure proof correctness and state consistency so the transaction doesn't fail on-ledger, issuers should follow the recommended flow for confidential clawbacks:
+
+1. [Lock](https://xrpl.org/docs/concepts/tokens/fungible-tokens/deep-freeze#how-does-mpt-freezelock-behavior-differ-from-iou) the MPT issuance for the holder by sending an [MPTokenIssuanceSet transaction](https://xrpl.org/docs/references/protocol/transactions/types/mptokenissuanceset) with the `tfMPTLock` flag enabled.
+2. Submit the ConfidentialMPTClawback transaction.
+
+{% /admonition %}
+
 Validators verify the proof provides cryptographic certainty that the plaintext amount matches the encrypted balance. If valid, both the holder's spending and inbox balances are set to encrypted zero, the version counter is reset to 0, and the clawed back tokens are removed from circulation.
 
 ## Privacy Controls

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
@@ -40,7 +40,7 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `Holder`                  | String    | AccountID         | Yes       | The account from which funds are being clawed back. |
 | `MPTokenIssuanceID`       | String    | UInt192           | Yes       | The unique identifier for the MPT issuance. |
 | `MPTAmount`               | String    | UInt64            | Yes       | The plaintext total amount being removed. |
-| `ZKProof`                 | String    | Blob              | Yes       | A 64-byte compact Clawback sigma proof that proves the issuer's on-ledger encrypted balance mirror (`sfIssuerEncryptedBalance`) encrypts the plaintext `MPTAmount`. |
+| `ZKProof`                 | String    | Blob              | Yes       | A 64-byte compact Clawback sigma proof that proves the issuer's on-ledger balance mirror (`IssuerEncryptedBalance`) decrypts to the plaintext total amount (`MPTAmount`) being clawed back. |
 
 ## Error Cases
 
@@ -53,8 +53,8 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `temBAD_AMOUNT`         | `MPTAmount` is zero or exceeds the maximum limits. |
 | `tecNO_TARGET`          | The `Holder` account does not exist. |
 | `tecOBJECT_NOT_FOUND`   | The `MPTokenIssuance` or the holder's `MPToken` object does not exist. |
-| `tecNO_PERMISSION`      | The transaction lacks the required permissions. This can occur if:<ul><li>The issuance does not have the **Can Clawback** flag set.</li><li>The issuance is missing the `sfIssuerEncryptionKey`.</li><li>The holder's `MPToken` is missing the `sfIssuerEncryptedBalance`.</li></ul> |
-| `tecINSUFFICIENT_FUNDS` | The `MPTAmount` exceeds the global `sfConfidentialOutstandingAmount`. |
-| `tecBAD_PROOF`          | The ZKP fails to prove that the `sfIssuerEncryptedBalance` (the mirror balance) encrypts the plaintext `MPTAmount`. |
+| `tecNO_PERMISSION`      | The transaction lacks the required permissions. This can occur if:<ul><li>The issuance does not have the **Can Clawback** flag set.</li><li>The issuance is missing the `IssuerEncryptionKey`.</li><li>The holder's `MPToken` is missing the `IssuerEncryptedBalance`.</li></ul> |
+| `tecINSUFFICIENT_FUNDS` | The `MPTAmount` exceeds the global `ConfidentialOutstandingAmount`. |
+| `tecBAD_PROOF`          | The ZKP fails to prove that the `IssuerEncryptedBalance` (the mirror balance) encrypts the plaintext `MPTAmount`. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
@@ -40,7 +40,7 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `Holder`                  | String    | AccountID         | Yes       | The account from which funds are being clawed back. |
 | `MPTokenIssuanceID`       | String    | UInt192           | Yes       | The unique identifier for the MPT issuance. |
 | `MPTAmount`               | String    | UInt64            | Yes       | The plaintext total amount being removed. |
-| `ZKProof`                 | String    | Blob              | Yes       | An Equality Proof validating the amount. |
+| `ZKProof`                 | String    | Blob              | Yes       | A 64-byte compact Clawback sigma proof that proves the issuer's on-ledger encrypted balance mirror (`sfIssuerEncryptedBalance`) encrypts the plaintext `MPTAmount`. |
 
 ## Error Cases
 

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptclawback.md
@@ -13,6 +13,10 @@ Claw back a holder's _entire_ confidential balance (inbox and spending), removin
 
 Unlike a regular [Clawback](https://xrpl.org/docs/references/protocol/transactions/types/clawback), confidential balances are encrypted, so the issuer must provide the plaintext total amount to claw back and a Zero-Knowledge Proof (ZKP) validating the amount.
 
+{% admonition type="danger" name="Warning" %}
+Issuers should **lock** the MPT issuance for the holder before submitting this transaction to ensure state consistency during proof verification. See [Confidential Clawback](../../concepts/confidential-transfers#confidential-clawback).
+{% /admonition %}
+
 _(Requires the [ConfidentialTransfers amendment][] {% not-enabled /%})_
 
 ## Example {% $frontmatter.seo.title %} JSON

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvert.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvert.md
@@ -49,7 +49,7 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `HolderEncryptionKey`     | String    | Blob              | No        | The holder's ElGamal public key for confidential balances. Required when enabling confidential transfers for the first time. Forbidden if a key is already registered. |
 | `HolderEncryptedAmount`   | String    | Blob              | Yes       | 66-byte ElGamal ciphertext credited to the holder's inbox balance. |
 | `IssuerEncryptedAmount`   | String    | Blob              | Yes       | 66-byte ElGamal ciphertext credited to the issuer's mirror balance. |
-| `AuditorEncryptedAmount`  | String    | Blob              | No        | A 66-byte ElGamal Ciphertext for the auditor. Required if `sfAuditorEncryptionKey` is present on the issuance. |
+| `AuditorEncryptedAmount`  | String    | Blob              | No        | A 66-byte ElGamal Ciphertext for the auditor. Required if `AuditorEncryptionKey` is present on the issuance. |
 | `BlindingFactor`          | String    | UInt256           | Yes       | The 32-byte scalar value used to encrypt the amount. Used by validators to verify the ciphertexts match the plaintext `MPTAmount`. |
 | `ZKProof`                 | String    | Blob              | No        | A Schnorr Proof of Knowledge. Required only when `HolderEncryptionKey` is present. |
 
@@ -63,7 +63,7 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `temMALFORMED`          | The transaction is malformed for one of the following reasons:<ul><li>`HolderEncryptionKey` is provided but `ZKProof` is not.</li><li>`HolderEncryptionKey` is not provided but `ZKProof` is.</li><li>`HolderEncryptionKey` length is not exactly 33 bytes.</li><li>`BlindingFactor` length is not 32 bytes.</li><li>`ZKProof` length is not 64 bytes.</li></ul> |
 | `temBAD_AMOUNT`         | The `MPTAmount` is less than 0 or exceeds the maximum allowable MPT amount. |
 | `temBAD_CIPHERTEXT`     | One or more encrypted amount fields (`HolderEncryptedAmount`, `IssuerEncryptedAmount`, or `AuditorEncryptedAmount`) have incorrect length or represent an invalid elliptic curve point. |
-| `tecNO_PERMISSION`      | The issuance has `sfAuditorEncryptionKey` set, but the transaction does not include `sfAuditorEncryptedAmount`. |
+| `tecNO_PERMISSION`      | The issuance has `AuditorEncryptionKey` set, but the transaction does not include `AuditorEncryptedAmount`. |
 | `tecDUPLICATE`          | A public key is provided in the transaction, but the account already has a registered key. |
 | `tecINSUFFICIENT_FUNDS` | The holder does not have sufficient public MPT balance to cover the MPTAmount. |
 | `tecBAD_PROOF`          | The ZKP verification failed for one of the following reasons:<ul><li>The `BlindingFactor` fails to reconstruct the provided ciphertexts given the plaintext `MPTAmount`.</li><li>The Schnorr ZKP fails to verify the holder's knowledge of the secret key.</li></ul> |

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvert.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvert.md
@@ -60,7 +60,7 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | Error Code              | Description |
 |:----------------------- |:----------- |
 | `temDISABLED`           | The ConfidentialTransfers amendment is not enabled. |
-| `temMALFORMED`          | The transaction is malformed for one of the following reasons:<ul><li>`HolderEncryptionKey` is provided but `ZKProof` is not.</li><li>`HolderEncryptionKey` is not provided but `ZKProof` is.</li><li>`HolderEncryptionKey` length is not exactly 64 bytes.</li><li>`BlindingFactor` length is not 32 bytes.</li><li>`ZKProof` length is not 65 bytes.</li></ul> |
+| `temMALFORMED`          | The transaction is malformed for one of the following reasons:<ul><li>`HolderEncryptionKey` is provided but `ZKProof` is not.</li><li>`HolderEncryptionKey` is not provided but `ZKProof` is.</li><li>`HolderEncryptionKey` length is not exactly 33 bytes.</li><li>`BlindingFactor` length is not 32 bytes.</li><li>`ZKProof` length is not 64 bytes.</li></ul> |
 | `temBAD_AMOUNT`         | The `MPTAmount` is less than 0 or exceeds the maximum allowable MPT amount. |
 | `temBAD_CIPHERTEXT`     | One or more encrypted amount fields (`HolderEncryptedAmount`, `IssuerEncryptedAmount`, or `AuditorEncryptedAmount`) have incorrect length or represent an invalid elliptic curve point. |
 | `tecNO_PERMISSION`      | The issuance has `sfAuditorEncryptionKey` set, but the transaction does not include `sfAuditorEncryptedAmount`. |

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvertback.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvertback.md
@@ -45,9 +45,9 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 |:------------------------- |:--------- |:----------------- |:--------- |:------------|
 | `MPTokenIssuanceID`       | String    | UInt192           | Yes       | The unique identifier for the MPT issuance. |
 | `MPTAmount`               | String    | UInt64            | Yes       | The plaintext amount to credit to the public balance. |
-| `HolderEncryptedAmount`   | String    | Blob              | Yes       | 66-byte Ciphertext to be subtracted from the holder's `sfConfidentialBalanceSpending`. |
+| `HolderEncryptedAmount`   | String    | Blob              | Yes       | 66-byte Ciphertext to be subtracted from the holder's `ConfidentialBalanceSpending`. |
 | `IssuerEncryptedAmount`   | String    | Blob              | Yes       | 66-byte Ciphertext to be subtracted from the issuer's mirror balance. |
-| `AuditorEncryptedAmount`  | String    | Blob              | No        | 66-byte Ciphertext for the auditor. Required if `sfAuditorEncryptionKey` is present on the issuance. |
+| `AuditorEncryptedAmount`  | String    | Blob              | No        | 66-byte Ciphertext for the auditor. Required if `AuditorEncryptionKey` is present on the issuance. |
 | `BlindingFactor`          | String    | UInt256           | Yes       | The 32-byte scalar value used to encrypt the amount. Used by validators to verify the ciphertexts match the plaintext `MPTAmount`. |
 | `BalanceCommitment`       | String    | Blob              | Yes       | A 33-byte cryptographic commitment to the user's confidential spending balance. |
 | `ZKProof`                 | String    | Blob              | Yes       | An 816-byte proof bundle containing a compact ConvertBack sigma proof and a single Bulletproof range proof. See [Proof Structure](#proof-structure) for details. |
@@ -72,7 +72,7 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `temBAD_AMOUNT`         | `MPTAmount` is zero or greater than the maximum allowable supply. |
 | `tecOBJECT_NOT_FOUND`   | The `MPToken` or `MPTokenIssuance` does not exist. |
 | `tecNO_PERMISSION`      | One of the following occurred:<ul><li>The issuance does not have the **Can Confidential Amount** flag.</li><li>The user's `MPToken` is missing the `ConfidentialBalanceSpending` or `HolderEncryptionKey` fields.</li><li>The issuance has `AuditorEncryptionKey` set but the transaction does not include `AuditorEncryptedAmount`.</li></ul> |
-| `tecINSUFFICIENT_FUNDS` | The global `sfConfidentialOutstandingAmount` is less than the requested `MPTAmount`, or the user's confidential balance is insufficient. |
+| `tecINSUFFICIENT_FUNDS` | The global `ConfidentialOutstandingAmount` is less than the requested `MPTAmount`, or the user's confidential balance is insufficient. |
 | `tecBAD_PROOF`          | One of the following occurred:<ul><li>The `BlindingFactor` fails to verify the integrity of the ciphertexts.</li><li>The provided `ZKProof` fails the compact sigma or range proof check.</li></ul> |
 | `tecLOCKED`             | The MPT asset is locked for the account, or the asset is globally locked. |
 

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvertback.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptconvertback.md
@@ -12,7 +12,7 @@ labels:
 Convert your confidential MPT balance back to a public balance. This debits the confidential spending balance and credits the public balance with the plaintext amount. For the issuer's _second account_, this returns confidential supply to the issuer account reserve.
 
 {% admonition type="info" name="Note" %}
-Only the spending balance can be converted back. Amounts in the inbox must first be merged into the spending balance using [ConfidentialMPTMergeInbox][].
+Only the spending balance can be converted back. Amounts in the inbox must first be merged into the spending balance using the [ConfidentialMPTMergeInbox transaction][].
 {% /admonition %}
 
 _(Requires the [ConfidentialTransfers amendment][] {% not-enabled /%})_
@@ -49,8 +49,16 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `IssuerEncryptedAmount`   | String    | Blob              | Yes       | 66-byte Ciphertext to be subtracted from the issuer's mirror balance. |
 | `AuditorEncryptedAmount`  | String    | Blob              | No        | 66-byte Ciphertext for the auditor. Required if `sfAuditorEncryptionKey` is present on the issuance. |
 | `BlindingFactor`          | String    | UInt256           | Yes       | The 32-byte scalar value used to encrypt the amount. Used by validators to verify the ciphertexts match the plaintext `MPTAmount`. |
-| `ZKProof`                 | String    | Blob              | Yes       | A bundle containing the Pedersen Linkage Proof (linking the ElGamal balance to the commitment) and the Range Proof. |
 | `BalanceCommitment`       | String    | Blob              | Yes       | A 33-byte cryptographic commitment to the user's confidential spending balance. |
+| `ZKProof`                 | String    | Blob              | Yes       | An 816-byte proof bundle containing a compact ConvertBack sigma proof and a single Bulletproof range proof. See [Proof Structure](#proof-structure) for details. |
+
+## Proof Structure
+
+The `ZKProof` field contains an 816-byte bundle made up of two parts:
+
+- A **compact ConvertBack sigma proof (128 bytes)** that verifies the holder owns the spending balance and that the `BalanceCommitment` is correctly derived from it.
+
+- A **single Bulletproof range proof (688 bytes)** that verifies that the remaining balance after withdrawal is non-negative.
 
 ## Error Cases
 
@@ -65,7 +73,7 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `tecOBJECT_NOT_FOUND`   | The `MPToken` or `MPTokenIssuance` does not exist. |
 | `tecNO_PERMISSION`      | One of the following occurred:<ul><li>The issuance does not have the **Can Confidential Amount** flag.</li><li>The user's `MPToken` is missing the `ConfidentialBalanceSpending` or `HolderEncryptionKey` fields.</li><li>The issuance has `AuditorEncryptionKey` set but the transaction does not include `AuditorEncryptedAmount`.</li></ul> |
 | `tecINSUFFICIENT_FUNDS` | The global `sfConfidentialOutstandingAmount` is less than the requested `MPTAmount`, or the user's confidential balance is insufficient. |
-| `tecBAD_PROOF`          | One of the following occurred:<ul><li>The `BlindingFactor` fails to verify the integrity of the ciphertexts.</li><li>The `ZKProof` fails the Pedersen Linkage check (proving the commitment matches the on-ledger balance).</li><li>The `ZKProof` fails the Range Proof (proving the remaining balance is non-negative).</li></ul> |
+| `tecBAD_PROOF`          | One of the following occurred:<ul><li>The `BlindingFactor` fails to verify the integrity of the ciphertexts.</li><li>The provided `ZKProof` fails the compact sigma or range proof check.</li></ul> |
 | `tecLOCKED`             | The MPT asset is locked for the account, or the asset is globally locked. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptmergeinbox.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptmergeinbox.md
@@ -47,7 +47,7 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `temDISABLED`           | The ConfidentialTransfer amendment is not enabled. |
 | `temMALFORMED`          | The account submitting the transaction is the Issuer. |
 | `tecOBJECT_NOT_FOUND`   | The `MPTokenIssuance` or the user's `MPToken` object does not exist. |
-| `tecNO_PERMISSION`      | The issuance does not have the **Can Confidential Amount** flag enabled, or the user's `MPToken` object has not been initialized (missing `sfConfidentialBalanceInbox` or `sfConfidentialBalanceSpending`). |
+| `tecNO_PERMISSION`      | The issuance does not have the **Can Confidential Amount** flag enabled, or the user's `MPToken` object has not been initialized (missing `ConfidentialBalanceInbox` or `ConfidentialBalanceSpending`). |
 | `tefINTERNAL`           | A system invariant failure where the issuer attempts to merge. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptsend.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptsend.md
@@ -49,7 +49,7 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `ZKProof`                 | String    | Blob              | Yes       | A 946-byte proof bundle containing a compact Send sigma proof and an aggregated Bulletproof range proof. See [Proof Structure](#proof-structure) for details. |
 | `AmountCommitment`        | String    | Blob              | Yes       | A cryptographic commitment to the amount being transferred. |
 | `BalanceCommitment`       | String    | Blob              | Yes       | A cryptographic commitment to the user's confidential spending balance. |
-| `AuditorEncryptedAmount`  | String    | Blob              | No        | Ciphertext for the auditor. Required if `sfAuditorEncryptionKey` is present on the issuance. |
+| `AuditorEncryptedAmount`  | String    | Blob              | No        | Ciphertext for the auditor. Required if `AuditorEncryptionKey` is present on the issuance. |
 | `CredentialIDs`           | Array     | Vector256         | No        | Array of Credential IDs. If present, the transaction can only succeed if the sender is authorized by credentials that match these IDs. |
 
 ## Proof Structure

--- a/docs/xls-96-confidential-transfers/references/transactions/confidentialmptsend.md
+++ b/docs/xls-96-confidential-transfers/references/transactions/confidentialmptsend.md
@@ -46,11 +46,23 @@ In addition to the [common fields](https://xrpl.org/docs/references/protocol/tra
 | `SenderEncryptedAmount`   | String    | Blob              | Yes       | Ciphertext used to homomorphically debit the sender's spending balance. |
 | `DestinationEncryptedAmount` | String | Blob              | Yes       | Ciphertext credited to the receiver's inbox balance. |
 | `IssuerEncryptedAmount`   | String    | Blob              | Yes       | Ciphertext used to update the issuer mirror balance. |
-| `ZKProof`                 | String    | Blob              | Yes       | ZKP bundle establishing equality, linkage, and range sufficiency. |
+| `ZKProof`                 | String    | Blob              | Yes       | A 946-byte proof bundle containing a compact Send sigma proof and an aggregated Bulletproof range proof. See [Proof Structure](#proof-structure) for details. |
 | `AmountCommitment`        | String    | Blob              | Yes       | A cryptographic commitment to the amount being transferred. |
 | `BalanceCommitment`       | String    | Blob              | Yes       | A cryptographic commitment to the user's confidential spending balance. |
 | `AuditorEncryptedAmount`  | String    | Blob              | No        | Ciphertext for the auditor. Required if `sfAuditorEncryptionKey` is present on the issuance. |
 | `CredentialIDs`           | Array     | Vector256         | No        | Array of Credential IDs. If present, the transaction can only succeed if the sender is authorized by credentials that match these IDs. |
+
+## Proof Structure
+
+The `ZKProof` field contains a 946-byte bundle made up of two parts:
+
+- A **compact Send sigma proof (192 bytes)** which simultaneously verifies:
+
+  - **Ciphertext consistency:** All encrypted copies of the transfer amount (sender, receiver, issuer, and optional auditor) encrypt the same value.
+  - **Amount linkage:** The `AmountCommitment` commits to the same transfer amount as the ciphertexts.
+  - **Balance linkage:** The `BalanceCommitment` encodes the same spending balance as the sender's on-ledger encrypted balance.
+
+- An **aggregated Bulletproof range proof (754 bytes)** which verifies that both the transfer amount and the remaining balance are non-negative.
 
 ## Error Cases
 
@@ -67,6 +79,6 @@ Besides errors that can occur for all transactions, {% code-page-name /%} transa
 | `tecNO_ENTRY`           | A credential ID specified in `CredentialIDs` does not exist on the ledger. |
 | `tecEXPIRED`            | A credential specified in `CredentialIDs` has expired. |
 | `terFROZEN`             | Either the sender or receiver's balance is currently frozen. |
-| `tecBAD_PROOF`          | The provided Zero-Knowledge Proof fails to verify equality or range constraints. This can occur if the proof was generated with an outdated `ConfidentialBalanceVersion`. |
+| `tecBAD_PROOF`          | The provided Zero-Knowledge Proof fails the compact sigma or range proof check. This can occur if the proof was generated with an outdated `ConfidentialBalanceVersion`. |
 
 {% raw-partial file="/docs/_snippets/common-links.md" /%}


### PR DESCRIPTION
This change adds:

- [x] Minor changes to support Zero-Knowledge Proof updates in the XLS spec. See XLS PR here: https://github.com/XRPLF/XRPL-Standards/pull/518/changes.
- [x] Document that transfer fee must be 0 to use confidential transfer. See https://ripplelabs.atlassian.net/browse/DEFI-661.
- [x] Document special transaction cost for confidential transactions now that we have it. See https://github.com/XRPLF/rippled/pull/7063

**UPDATE**
- [x] Update the docs to tell users the recommended flow for clawback.
Some background: For Confidential MPTs (XLS-96), a freeze/lock transaction before clawback is important since the clawback proof can become stale during validation if the holder's confidential balance (either Spending Balance or Inbox Balance) changes. To ensure proof correctness, the holder's confidential balance must remain completely stable between proof generation and validation. 
