### PR TITLE
Update documentation link in index.page.tsx for MPT DEX

### DIFF
--- a/docs/xls-82-mpt-dex/index.page.tsx
+++ b/docs/xls-82-mpt-dex/index.page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Documentation" to="https://xrpl-dev-portal--xls-82-mpt-dex.preview.redocly.app/docs/concepts/tokens/decentralized-exchange">
+          <Card title="Documentation" to="https://xrpl-dev-portal--d70d45.preview.redocly.app/docs/concepts/tokens/decentralized-exchange">
             <p>Explore key concepts, find detailed references, and follow
               step-by-step tutorials.</p>
             <Button size="large" variant="primary">Read the Docs</Button>


### PR DESCRIPTION
I merged the MPT DEX docs updates into the [release-3.4.0 branch](https://github.com/XRPLF/xrpl-dev-portal/pull/3660), so we need to point to the preview for that branch now.