### PR TITLE
Update landing pages with Tutorials card + add lending demo app

### DIFF
--- a/docs/xls-33-multi-purpose-tokens/index.page.tsx
+++ b/docs/xls-33-multi-purpose-tokens/index.page.tsx
@@ -69,13 +69,13 @@ export default function Page() {
           </Card>
 
           <Card
-            title="Documentation"
+            title="Concepts"
             to="https://xrpl.org/docs/concepts/tokens/fungible-tokens/multi-purpose-tokens"
           >
             <p>
               Documentation on the feature, including how it works and why.
             </p>
-            <ButtonToXRPL>Read the Docs</ButtonToXRPL>
+            <ButtonToXRPL>Read the Concepts</ButtonToXRPL>
           </Card>
           <Card
             title="Blog"

--- a/docs/xls-33-multi-purpose-tokens/index.page.tsx
+++ b/docs/xls-33-multi-purpose-tokens/index.page.tsx
@@ -73,8 +73,7 @@ export default function Page() {
             to="https://xrpl.org/docs/concepts/tokens/fungible-tokens/multi-purpose-tokens"
           >
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>Read the Docs</ButtonToXRPL>
           </Card>
@@ -88,9 +87,16 @@ export default function Page() {
             <Button size="large" variant="primary">
               Read the Blog
             </Button>
+          </Card>
+          <Card
+            title="Tutorials"
+            to="https://xrpl.org/docs/tutorials/tokens/mpts/issue-a-multi-purpose-token"
+          >
+            <p>
+              Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>Read the Tutorials</ButtonToXRPL>
           </Card>          
-        </Cards>
-        <Cards columns={3}>
           <Card
             title="Use Cases"
             to="https://xrpl.org/docs/use-cases/tokenization/creating-an-asset-backed-multi-purpose-token"

--- a/docs/xls-56-batch-transactions/index.page.tsx
+++ b/docs/xls-56-batch-transactions/index.page.tsx
@@ -69,13 +69,13 @@ export default function Page() {
           </Card>
 
           <Card
-            title="Documentation"
+            title="Concepts"
             to="https://xrpl.org/docs/concepts/transactions/batch-transactions"
           >
             <p>
               Documentation on the feature, including how it works and why.
             </p>
-            <ButtonToXRPL>Read the Docs</ButtonToXRPL>
+            <ButtonToXRPL>Read the Concepts</ButtonToXRPL>
           </Card>
           <Card
             title="Tutorials"

--- a/docs/xls-56-batch-transactions/index.page.tsx
+++ b/docs/xls-56-batch-transactions/index.page.tsx
@@ -54,7 +54,7 @@ export default function Page() {
           onKeyDatesUpdate={handleKeyDatesUpdate}
         />
 
-        <Cards columns={2}>
+        <Cards columns={3}>
           <Card
             title="XLS Spec"
             to="https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0056d-batch"
@@ -73,10 +73,18 @@ export default function Page() {
             to="https://xrpl.org/docs/concepts/transactions/batch-transactions"
           >
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>Read the Docs</ButtonToXRPL>
+          </Card>
+          <Card
+            title="Tutorials"
+            to="https://xrpl.org/docs/tutorials/best-practices/transaction-sending/send-a-single-account-batch-transaction"
+          >
+            <p>
+              Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>Read the Tutorials</ButtonToXRPL>
           </Card>
           <Card title="Security Audit" to="https://www.halborn.com/audits/ripple/ripple---batch---smart-contract-assessment-420598">
             <p>

--- a/docs/xls-65-single-asset-vault/index.page.tsx
+++ b/docs/xls-65-single-asset-vault/index.page.tsx
@@ -68,14 +68,6 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/single-asset-vaults">
-            <p>
-              Documentation on the feature, including how it works and why.
-            </p>
-            <ButtonToXRPL>
-              Read the Docs
-            </ButtonToXRPL>
-          </Card>
           <Card
             title="Blog"
             to="https://dev.to/ripplexdev/xrp-ledger-lending-protocol-2pla">
@@ -93,6 +85,14 @@ export default function Page() {
             <Button size="large" variant="primary">
               Read the Article
             </Button>
+          </Card>
+          <Card title="Concepts" to="https://xrpl.org/docs/concepts/tokens/single-asset-vaults">
+            <p>
+              Documentation on the feature, including how it works and why.
+            </p>
+            <ButtonToXRPL>
+              Read the Concepts
+            </ButtonToXRPL>
           </Card>
           <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/defi/lending/use-single-asset-vaults/create-a-single-asset-vault">
             <p>

--- a/docs/xls-65-single-asset-vault/index.page.tsx
+++ b/docs/xls-65-single-asset-vault/index.page.tsx
@@ -70,8 +70,7 @@ export default function Page() {
 
           <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/single-asset-vaults">
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>
               Read the Docs
@@ -93,6 +92,22 @@ export default function Page() {
             </p>
             <Button size="large" variant="primary">
               Read the Article
+            </Button>
+          </Card>
+          <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/defi/lending/use-single-asset-vaults/create-a-single-asset-vault">
+            <p>
+             Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>
+              Read the Tutorials
+            </ButtonToXRPL>
+          </Card>
+          <Card title="Demo App" to="https://lending.xls-demo.com/">
+            <p>
+              Explore a full lending platform built on the Lending Protocol and Single Asset Vaults, featuring dedicated dashboards for brokers, depositors, and borrowers.
+            </p>
+            <Button size="large" variant="primary">
+              Try the Demo App
             </Button>
           </Card>
           <Card

--- a/docs/xls-66-lending-protocol/index.page.tsx
+++ b/docs/xls-66-lending-protocol/index.page.tsx
@@ -67,14 +67,6 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/lending-protocol">
-            <p>
-              Documentation on the feature, including how it works and why.
-            </p>
-            <ButtonToXRPL>
-              Read the Docs
-            </ButtonToXRPL>
-          </Card>
           <Card title="Blog" to="https://dev.to/ripplexdev/xrp-ledger-lending-protocol-2pla">
             <p>
               An overview of the feature and why it matters to developers, explained in our blog post.
@@ -90,7 +82,15 @@ export default function Page() {
             <Button size="large" variant="primary">
               Read the Article
             </Button>
-          </Card>   
+          </Card>
+          <Card title="Concepts" to="https://xrpl.org/docs/concepts/tokens/lending-protocol">
+            <p>
+              Documentation on the feature, including how it works and why.
+            </p>
+            <ButtonToXRPL>
+              Read the Concepts
+            </ButtonToXRPL>
+          </Card>
           <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/defi/lending/use-the-lending-protocol/create-a-loan-broker">
             <p>
              Follow step-by-step tutorials to start building.

--- a/docs/xls-66-lending-protocol/index.page.tsx
+++ b/docs/xls-66-lending-protocol/index.page.tsx
@@ -69,8 +69,7 @@ export default function Page() {
 
           <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/lending-protocol">
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>
               Read the Docs
@@ -92,6 +91,22 @@ export default function Page() {
               Read the Article
             </Button>
           </Card>   
+          <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/defi/lending/use-the-lending-protocol/create-a-loan-broker">
+            <p>
+             Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>
+              Read the Tutorials
+            </ButtonToXRPL>
+          </Card>
+          <Card title="Demo App" to="https://lending.xls-demo.com/">
+            <p>
+              Explore a full lending platform built on the Lending Protocol and Single Asset Vaults, featuring dedicated dashboards for brokers, depositors, and borrowers.
+            </p>
+            <Button size="large" variant="primary">
+              Try the Demo App
+            </Button>
+          </Card>
           <Card title="Security Audit" to="https://www.halborn.com/audits/ripple/lending-protocol-re-audit-2769d2">
             <p>
               The security audit performed by third-party security experts, including a link to the full, detailed security audit report.

--- a/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
+++ b/docs/xls-68-sponsored-fees-and-reserves/index.page.tsx
@@ -52,7 +52,7 @@ export default function Page() {
           onKeyDatesUpdate={handleKeyDatesUpdate}
         />
 
-        <Cards columns={2}>
+        <Cards columns={3}>
           <Card
             title="XLS Spec"
             to="https://xls.xrpl.org/xls/XLS-0068-sponsored-fees-and-reserves.html"

--- a/docs/xls-70-credentials/index.page.tsx
+++ b/docs/xls-70-credentials/index.page.tsx
@@ -53,13 +53,13 @@ export default function Page() {
           </Card>
 
           <Card
-            title="Documentation"
+            title="Concepts"
             to="https://xrpl.org/docs/concepts/decentralized-storage/credentials"
           >
             <p>
               Documentation on the feature, including how it works and why.
             </p>
-            <ButtonToXRPL>Read the Docs</ButtonToXRPL>
+            <ButtonToXRPL>Read the Concepts</ButtonToXRPL>
           </Card>
 
           <Card

--- a/docs/xls-70-credentials/index.page.tsx
+++ b/docs/xls-70-credentials/index.page.tsx
@@ -38,7 +38,7 @@ export default function Page() {
           keyDates={keyDates}
         />
 
-        <Cards columns={2}>
+        <Cards columns={3}>
           <Card
             title="XLS Spec"
             to="https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0070-credentials"
@@ -57,13 +57,11 @@ export default function Page() {
             to="https://xrpl.org/docs/concepts/decentralized-storage/credentials"
           >
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>Read the Docs</ButtonToXRPL>
           </Card>
-        </Cards>
-        <Cards columns={2}>
+
           <Card
             title="Blog"
             to="https://www.idos.network/blog/debate-contribution-xrpl-credentials-are-a-game-changer?ref=twitter"
@@ -76,6 +74,15 @@ export default function Page() {
             </Button>
           </Card>
           <Card
+            title="Tutorials"
+            to="https://xrpl.org/docs/tutorials/compliance-features/manage-credentials"
+          >
+            <p>
+              Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>Read the Tutorials</ButtonToXRPL>
+          </Card>
+          <Card
             title="Security Audit"
             to="https://www.halborn.com/audits/ripple/ripple---smart-contract-audit---credentials-c092b3"
           >
@@ -86,7 +93,6 @@ export default function Page() {
               Read the Security Audit Report
             </Button>
           </Card>
-
         </Cards>        
       </LandingContainer>
     </LandingLayout>

--- a/docs/xls-75-permission-delegation/index.page.tsx
+++ b/docs/xls-75-permission-delegation/index.page.tsx
@@ -74,9 +74,19 @@ export default function Page() {
               Read the Blog
             </Button>
           </Card>
-        </Cards>
 
-        <Cards columns={2}>
+          <Card
+            title="Code Samples"
+            to="https://github.com/XRPLF/xrpl-dev-portal/tree/master/_code-samples/delegate-permissions/"
+          >
+            <p>
+              Explore working code samples to get started.
+            </p>
+            <ButtonToXRPL>
+              View the Code Samples
+            </ButtonToXRPL>
+          </Card>
+
           <Card
             title="Security Audit"
             to="https://dev.to/ripplexdev/permission-delegation-security-audit-findings-2h83"

--- a/docs/xls-80-permissioned-domains/index.page.tsx
+++ b/docs/xls-80-permissioned-domains/index.page.tsx
@@ -46,10 +46,10 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/decentralized-exchange/permissioned-domains">
+          <Card title="Concepts" to="https://xrpl.org/docs/concepts/tokens/decentralized-exchange/permissioned-domains">
             <p>Documentation on the feature, including how it works and why.</p>
             <ButtonToXRPL>
-              Read the Docs
+              Read the Concepts
             </ButtonToXRPL>
           </Card>
 

--- a/docs/xls-80-permissioned-domains/index.page.tsx
+++ b/docs/xls-80-permissioned-domains/index.page.tsx
@@ -47,7 +47,7 @@ export default function Page() {
           </Card>
 
           <Card title="Documentation" to="https://xrpl.org/docs/concepts/tokens/decentralized-exchange/permissioned-domains">
-            <p>Explore key concepts, find detailed references, and follow step-by-step tutorials.</p>
+            <p>Documentation on the feature, including how it works and why.</p>
             <ButtonToXRPL>
               Read the Docs
             </ButtonToXRPL>
@@ -58,6 +58,13 @@ export default function Page() {
             <Button size="large" variant="primary">
               Read the Blog
             </Button>
+          </Card>
+
+          <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/compliance-features/create-permissioned-domains-in-javascript">
+            <p>Follow step-by-step tutorials to start building.</p>
+            <ButtonToXRPL>
+              Read the Tutorials
+            </ButtonToXRPL>
           </Card>
 
           <Card title="QA Test Report" to="https://dev.to/ripplexdev/permissioned-domains-qa-test-report-3pjl">

--- a/docs/xls-85-token-escrow/index.page.tsx
+++ b/docs/xls-85-token-escrow/index.page.tsx
@@ -72,22 +72,25 @@ export default function Page() {
 
           <Card title="Documentation" to="https://xrpl.org/docs/concepts/payment-types/escrow">
             <p>
-              Explore key concepts, find detailed references, and follow
-              step-by-step tutorials.
+              Documentation on the feature, including how it works and why.
             </p>
             <ButtonToXRPL>Read the Docs</ButtonToXRPL>
           </Card>
-          
-          <Card title="Blog" to="https://dev.to/dangell7/xrpl-token-escrow-features-benefits-and-getting-started-2ogi"> 
+
+          <Card title="Blog" to="https://dev.to/dangell7/xrpl-token-escrow-features-benefits-and-getting-started-2ogi">
             <p>An overview of the feature and why it matters to institutional issuers, explained in our blog post.</p>
             <Button size="large" variant="primary">
               Read the Blog
             </Button>
-          </Card> 
-        </Cards>
-        
-       <Cards columns={2}>
-         <Card title="Security Audit" to="https://dev.to/ripplexdev/token-escrow-security-audit-findings-39hn">
+          </Card>
+          
+          <Card title="Tutorials" to="https://xrpl.org/docs/tutorials/payments/send-fungible-token-escrows">
+            <p>
+              Follow step-by-step tutorials to start building.
+            </p>
+            <ButtonToXRPL>Read the Tutorials</ButtonToXRPL>
+          </Card>
+          <Card title="Security Audit" to="https://dev.to/ripplexdev/token-escrow-security-audit-findings-39hn">
             <p>The security audit performed by third-party security experts, including a link to the full, detailed security audit report.
             </p>
             <Button size="large" variant="primary">

--- a/docs/xls-85-token-escrow/index.page.tsx
+++ b/docs/xls-85-token-escrow/index.page.tsx
@@ -70,11 +70,11 @@ export default function Page() {
             </Button>
           </Card>
 
-          <Card title="Documentation" to="https://xrpl.org/docs/concepts/payment-types/escrow">
+          <Card title="Concepts" to="https://xrpl.org/docs/concepts/payment-types/escrow">
             <p>
               Documentation on the feature, including how it works and why.
             </p>
-            <ButtonToXRPL>Read the Docs</ButtonToXRPL>
+            <ButtonToXRPL>Read the Concepts</ButtonToXRPL>
           </Card>
 
           <Card title="Blog" to="https://dev.to/dangell7/xrpl-token-escrow-features-benefits-and-getting-started-2ogi">


### PR DESCRIPTION
- Adds Tutorials cards linking to the first xrpl.org tutorial for each feature (where available).
- Adds Demo App card for Lending Protocol and SAV landing pages.
- Adds Code Samples card for Permissioned Delegation landing page. Since we don't have a tutorial at least we should point to the available code sample.